### PR TITLE
Cleanup Grunt setup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,12 +31,9 @@ module.exports = function(grunt) {
     qunit: {
       files: ['test/quail.html']
     },
-    jlint: {
-      
-    },
     watch: {
-      files: '<%= lint.files %>',
-      tasks: 'lint qunit'
+      files: '<%= jshint.files %>',
+      tasks: 'test'
     },
     jshint: {
       options: {
@@ -64,12 +61,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
-  // Default task.
-  grunt.registerTask('default', ['jshint', 'qunit']);
   
   // Release task.
-  grunt.registerTask('default', ['jshint', 'qunit', 'concat', 'uglify']);
+  grunt.registerTask('default', ['test', 'concat', 'uglify']);
   
-  // Travis task.
-  grunt.registerTask('travis', ['jshint', 'qunit']);
+  // Test task.
+  grunt.registerTask('test', ['jshint', 'qunit']);
 };

--- a/package.json
+++ b/package.json
@@ -7,16 +7,15 @@
     "node": ">= 0.6.0"
   },
   "scripts": {
-    "test": "grunt travis --verbose"
+    "test": "grunt test --verbose"
   },
   "devDependencies": {
-    "grunt": "~0.4.x",
+    "grunt": "~0.4.1",
     "grunt-contrib-qunit": "~0.2.0",
-    "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-uglify": "~0.1.2",
-    "grunt-contrib-jshint": "~0.2.0",
-    "grunt-contrib-watch": "~0.3.1",
-    "grunt-cli": "~0.1.6"
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-uglify": "~0.2.0",
+    "grunt-contrib-jshint": "~0.4.3",
+    "grunt-contrib-watch": "~0.3.1"
   },
   "jam": {
     "dependencies": {


### PR DESCRIPTION
- Remove empty "jlint" target
- Remove duplicate "default" task
- Fixed watch task that refrenced old "lint" target
- Renamed travis task to test
- Update grunt contrib devDependencies
- Removed grunt-cli as a devDependency as it is supposed to be global
  only
