### PR TITLE
Introduce a layer of test result reporting that can provide feedback on ...

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -2132,7 +2132,8 @@ imgHasAlt:
     - "image"
     - "content"
   options:
-    selector: "img:not(img[alt])"
+    selector: "img"
+    filter: ":not(img[alt])"
 imgHasLongDesc:
   type: "custom"
   testability: 1

--- a/test/composite.js
+++ b/test/composite.js
@@ -45,6 +45,17 @@ var quailTest = {
     });
   },
 
+  /**
+   * Compares the status of the test result to the resultType argument.
+   *
+   * @param string resultType
+   *   Possible values include: 'na', 'fail', 'pass'
+   * @return boolean
+   */
+  confirmStatus: function (resultType) {
+    return quailTest.results[quailTest.testName].status === 'pass';
+  },
+
   confirmIsEmpty : function() {
     $.each(quailTest.results[quailTest.testName].elements, function(index, item) {
       if(typeof item === 'undefined' ||

--- a/test/testfiles/common/imgHasAlt-pass.html
+++ b/test/testfiles/common/imgHasAlt-pass.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
-    
+
     <head>
         <title>imgHasAlt-pass</title>
         <link rel="stylesheet" href="../../../lib/qunit/qunit/qunit.css"
         media="screen">
     </head>
-    
+
     <body>
         <p>
             <img src="resources/rex.jpg" alt="A black and brown cat named Rex." />
@@ -18,7 +18,7 @@
         <script>
             test('imgHasAlt', function() {
                 quailTest.runTest('imgHasAlt');
-                equal(true, quailTest.confirmIsEmpty(), 'Item is empty');
+                equal(true, quailTest.confirmStatus('pass'), 'Image has an alt attribute');
               });
         </script>
     </body>


### PR DESCRIPTION
#101

These changes introduce a layer of processing on top of `quail.testFails()`. The change is meant to be backwards compatible with existing calls to testFails, that is now a deprecated function which simply delegates to `_processTestResult()`.

We now have three callbacks:

``` javascript
quail.options.testNotApplicable()
quail.options.testFailed()
quail.options.testPassed()
```

I also introduced a new helper function for QUnit test confirmation

``` javascript
/**
 * Compares the status of the test result to the resultType argument.
 *
 * @param string resultType
 *   Possible values include: 'na', 'fail', 'pass'
 * @return boolean
 */
confirmStatus: function (resultType) {
  return quailTest.results[quailTest.testName].status === 'pass';
},
```

I'm not sure yet if this is the right approach. But it's a decent first step to introducing the concept of a 'passed' test.

The array `quail.accessibilityResults[testName].elements` still contains only the failed test elements. I haven't gotten to updating it yet.

The bigger question is, do we want all of these individual callbacks or would we rather have a single 'complete' callback that receives a dense data object with passes, fails, na's and such that the invoking program would need to parse. I tend more towards simply relying on a complete callback, but I'd like to get  your opinion since I still don't have a good sense of how others have been using Quail up to now.

Signed-off-by: J. Renée Beach splendidnoise@gmail.com
