### PR TITLE
Add: Checks that build command is installed, otherwise exits

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,12 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+BUILDCHECK   := $(shell command -v $(SPHINXBUILD))
+
+# Check build script is installed
+ifeq ($(BUILDCHECK),)
+$(error Build command '$(SPHINXBUILD)' not found)
+endif
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4


### PR DESCRIPTION
Small check added to the documentation Makefile. If the build command isn't installed an error is throw and the make process exits.
