### PR TITLE
Add missing dependency for phantomjs lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "grunt-convert": "~0.1.5",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "~0.8.1",
-    "grunt-bower-task": "~0.3.4"
+    "grunt-bower-task": "~0.3.4",
+    "grunt-lib-phantomjs": "~0.3.1"
   },
   "jam": {
     "dependencies": {


### PR DESCRIPTION
aka. I don't know why grunt-contrib-qunit doesn't install it, it's already in it's package.json dependencies…
