### PR TITLE
Update dependencies to more recent versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jquery": ">1.4.2"
   },
   "devDependencies": {
-    "bower": "~1.2.8",
+    "bower": "~1.3.9",
     "grunt": "~0.4.1",
     "grunt-contrib-qunit": "~0.2.0",
     "grunt-contrib-concat": "~0.3.0",
@@ -26,7 +26,7 @@
     "grunt-convert": "~0.1.5",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "~0.8.1",
-    "grunt-bower-task": "~0.3.4"
+    "grunt-bower-task": "~0.4.0"
   },
   "jam": {
     "dependencies": {


### PR DESCRIPTION
We had trouble building Quail using Grunt, presumably due to outdated Bower dependencies.
