### PR TITLE
KINGUseLongDateFormat only checks paragraphs

### DIFF
--- a/src/js/custom/KINGUseLongDateFormat.js
+++ b/src/js/custom/KINGUseLongDateFormat.js
@@ -16,5 +16,9 @@ quail.KINGUseLongDateFormat = function (quail, test, Case) {
       'status': dateReg.test(text) ? 'failed' : 'passed'
     });
   }
-  test.get('$scope').find('p').each(testDateFormat);
+
+  // Note it should also contain div, but that would lead to other issues.
+  var appliableElements = 'a, article, aside, b, blockquote, caption, cite, dd, del, div, em, figcaption, footer, h1, h2, h3, h4, h5, h6, header, i, label, legend, li, mark, nav, option, p, q, s, section, small, span, strong, sub, summary, sup, td, th, title, u';
+
+  test.get('$scope').find(appliableElements).each(testDateFormat);
 };

--- a/test/accessibility-tests/KINGUseLongDateFormat.html
+++ b/test/accessibility-tests/KINGUseLongDateFormat.html
@@ -8,10 +8,33 @@
   <p>Text with a short date of 12/04/2014, 2/1/14, 12-04-12, 12.04.12.</p>
 </div>
 
+<div class="quail-test" data-expected="fail" data-accessibility-test="KINGUseLongDateFormat">
+  <ul>
+	<li>This list item contains short date: 12/04/2014</li>
+  </ul>
+</div>
+
+<div class="quail-test" data-expected="fail" data-accessibility-test="KINGUseLongDateFormat">
+  <table>
+	<tbody>
+	  <td>12/04/2014</td>
+	</tbody>
+  </table>
+</div>
+
+<div class="quail-test" data-expected="fail" data-accessibility-test="KINGUseLongDateFormat">
+  <h1>This headline has bad date format 12.4.2014.</h1>
+</div>
+
 <div class="quail-test" data-expected="pass" data-accessibility-test="KINGUseLongDateFormat">
   <p>Text with long date of 12 may 2014.</p>
 </div>
 
+<div class="quail-test" data-expected="pass" data-accessibility-test="KINGUseLongDateFormat">
+  <ul>
+	<li>Text with long date of 12 may 2014</li>
+  </ul>
+</div>
 
 <script src="../quail-testrunner.js"></script>	</body>
 </html>


### PR DESCRIPTION
# Problem

Currently test **KINGUseLongDateFormat** is performed only on `p` elements. There's much more elements to be checked, like `li`, `h1-h6`, `figcaption` etc.
## Sample TC

Consider following HTML to be checked by the Quail:

```
<h1>Short date 12-04-12</h1>
<p>Short date 12-04-12</p>
```

**Expected result:**
Quail should produce **2** fialed cases.
First for the `h1` element and second for the `p` element.

**Current result:**
Quail produces only **1** failed case.
Case is created only for `p` element.
## Proposed solution

Solution in pull request will add more elements to be inspected for invalid date pattern.
## Additional notes

While this issue will fix problems like mentioned in Sample TC it will cause other issue. Consider following HTML:

```
<ul>
    <li>
        <p>Short date 12-04-12</p>
    </li>
</ul>
```

With current design it will cause 2 failed cases, instead of 1. That's because KINGUseLongDateFormat is using `quail.getTextContents()` on each element matched by main selector.

Since we added `li` to the selector, it will perform quail.getTextContents() on both `li` and `p`. Both of these calls will return text containing invalid date.

In order to resolve this problem we should check only text directly in checked node. This fix we'll propose in separate Pull Request.

---

We should also think about adding `div` element into this list, but because of a problem mentioned above, I decided to do that later on.
## Complete test

Complete test file is placed in [gist](https://gist.github.com/mlewand/d5674183bf62f6b1c85e).

Just put it into quail directory (requires builded Quail, since it uses `dist`).
