### PR TITLE
KINGUseLongDateFormat is checking whole innerText of the element

### DIFF
--- a/src/js/custom/KINGUseLongDateFormat.js
+++ b/src/js/custom/KINGUseLongDateFormat.js
@@ -3,8 +3,31 @@ quail.KINGUseLongDateFormat = function (quail, test, Case) {
   function testDateFormat(index, element) {
     // Detect dates with several separators.
     var dateReg = /\d{1,2}([./-])\d{1,2}\1\d{2,4}/g;
+    var elemChildNodes = element.childNodes;
+    var issueOccured = false;
 
-    var text = quail.getTextContents($(element));
+    // Lets find all the *direct* text node children.
+    var textNodeChildren = [];
+    var i = 0;
+    var childCount;
+
+    for (childCount = elemChildNodes.length; i < childCount; i++) {
+      if (elemChildNodes[i].nodeType === Node.TEXT_NODE) {
+        textNodeChildren.push(elemChildNodes[i]);
+      }
+    }
+
+    // Now we're going to check if any text node matches the pattern.
+    // Micro-optimization: check also if issueOccured == false, because we
+    // are not reporting more than one issue occurence.
+    for (i = 0; i < textNodeChildren.length && !issueOccured; i++) {
+      var curTextContent = textNodeChildren[i].nodeValue;
+
+      if ( dateReg.test( curTextContent ) ) {
+        issueOccured = true;
+      }
+    }
+
     var _case = Case({
       element: this,
       expected: $(this).closest('.quail-test').data('expected')
@@ -13,7 +36,7 @@ quail.KINGUseLongDateFormat = function (quail, test, Case) {
 
     // Only test if there is one date in the wrong format and call it.
     _case.set({
-      'status': dateReg.test(text) ? 'failed' : 'passed'
+      'status': issueOccured ? 'failed' : 'passed'
     });
   }
   test.get('$scope').find('p').each(testDateFormat);

--- a/test/accessibility-tests/KINGUseLongDateFormat.html
+++ b/test/accessibility-tests/KINGUseLongDateFormat.html
@@ -9,6 +9,13 @@
 </div>
 
 <div class="quail-test" data-expected="pass" data-accessibility-test="KINGUseLongDateFormat">
+  <p>
+	Date nested in an unsupported tag
+	<small>12-04-12</small>
+  </p>
+</div>
+
+<div class="quail-test" data-expected="pass" data-accessibility-test="KINGUseLongDateFormat">
   <p>Text with long date of 12 may 2014.</p>
 </div>
 


### PR DESCRIPTION
# Problem

This is a follow-up of a #272 issue.

Currently test **KINGUseLongDateFormat** is checking whole innerText of inspecting element by calling `quail.getTextContents()`.
1. When we'll add a `li` element to the KINGUseLongDateFormat [inspected element selector](https://github.com/quailjs/quail/blob/589eb65dc73b8ed2c35f1d4c5d880e79677b9fc1/src/js/custom/KINGUseLongDateFormat.js#L19) it would check innerText of both `li` and its `p` elements.

That will result in extra failure cases. See TC1.
1. Also this change will make results more accurate, since case `element` will point to direct parent, rather than element which is very likely not to be an element which contains invalid text.
2. Finally it will allow to be more specific about issues count.
## Sample TC

**TC1.** Consider following HTML to be checked by the Quail:

```
<ul>
    <li>
        <p>Short date 12-04-12</p>
    </li>
</ul>
```

**Expected result:**
Quail should produce **1** fialed cases.
Case should be created only for the `p` element.

**Current result:**
Quail produces only **2** failed case.
First for the `li` element and second for the `p` element.
## Proposed solution

Solution in pull request will restrict checking to direct TextNode children.
## Additional notes

Proposed solution has an issue not present in original approach, that is it doesn't detecting "non-visible breakers".

By that I mean elements, which doesn't really have any text content in it. Eg.

```
<p>Short date 10.02<span></span>.2011</p>
```

Here ideally we'd like `span` to be ignored, and case still be failed.

We already solved this issue, however it adds some complexity to the code, so we'd like to propose this simplified solution first. If you're fine with this change, we'll send next pull request fixing this problem too.
## Complete test

Assuming that the KINGUseLongDateFormat [selector](https://github.com/quailjs/quail/blob/589eb65dc73b8ed2c35f1d4c5d880e79677b9fc1/src/js/custom/KINGUseLongDateFormat.js#L19) is changed to:
- match also `li`
- not match `font` tag

So it might look like: `test.get('$scope').find('p, li').each(testDateFormat);`

You might use following [gist file](https://gist.github.com/mlewand/ebdb9ff72c74f6c74bc1) to test TC1 problem.

Just put it into quail directory (requires builded Quail, since it uses `dist`).
