### PR TITLE
Fix for failing KINGUseLongDateFormat test

### DIFF
--- a/test/accessibility-tests/KINGUseLongDateFormat.html
+++ b/test/accessibility-tests/KINGUseLongDateFormat.html
@@ -27,9 +27,11 @@
 </div>
 
 <div class="quail-test" data-expected="pass" data-accessibility-test="KINGUseLongDateFormat">
+  <!-- Since we don't support <font/> element in KINGUseLongDateFormat test, this TC should not
+  cause an error -->
   <p>
 	Date nested in an unsupported tag
-	<small>12-04-12</small>
+	<font>12-04-12</font>
   </p>
 </div>
 


### PR DESCRIPTION
Ok so reason for the test to fail was actually integration of both pull requests (#272 and #273).

In one PR I've fixed the issue that Quail inspects whole innerText of the scope element.

So in order to test that case I've nested `small` element inside `p` - which was the only one element taken as a scope back then.

Then in second PR I've expanded the list of supported scope elements, where `small` also got added to the supported scope elements. That's `small` element in the test was inspected, and caused test to fail.

Now as a solution I have changed the `small` element into the `font` (which is not in a supported tags list). In addition to that I've added a small comment in TC with short explaination.
