### PR TITLE
Wrong title for imgAltIsTooLong test

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -2229,7 +2229,7 @@ imgAltIsTooLong:
   type: "custom"
   testability: 1
   title:
-    en: "Image Alt text is short"
+    en: "Image Alt text is too long"
     nl: "Altteksten voor een afbeelding zijn kort"
   description:
     en: "All \"alt\" attributes for <code>img</code> elements should be clear and concise. \"Alt\" attributes over 100 characters long should be reviewed to see if they are too long."


### PR DESCRIPTION
Hi,

The `imgAltIsTooLong` test title needs to be changed as it doesn't fully comply its purpose.

I've proposed change in this pull request.

There is still one thing to do. As I've checked in the translator it seems that `nl` translation should be adjusted too, however I'm not able to give you a reliable translation, so that's something that needs to be done.