### PR TITLE
Replaced kevee/quail with quailjs/quail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://secure.travis-ci.org/quailjs/quail.png?branch=master)](http://travis-ci.org/kevee/quail)
+[![Build Status](https://secure.travis-ci.org/quailjs/quail.png?branch=master)](http://travis-ci.org/quailjs/quail)
 
 Quail: Accessibility Information Library
 ========================================
@@ -13,7 +13,7 @@ You can include Quail into your project using Bower by using the command `bower 
 
 Building Quail
 --------------
-If you are not familiar with using grunt or just want to download a pre-built version of quail, [visit the releases page for the project](https://github.com/kevee/quail/releases).
+If you are not familiar with using grunt or just want to download a pre-built version of quail, [visit the releases page for the project](https://github.com/quailjs/quail/releases).
 
 If you are checking out quail from a repository, you will notice there is no `/dist` directory, quail must be built using [Grunt](http://gruntjs.com/). Use the following steps to get started (this is assuming you already have [Node](http://nodejs.org/) installed on your machine):
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -1,7 +1,7 @@
 Building QUAIL
 ==============
 
-For most purposes, you can simply `download the latest release of Quail <https://github.com/kevee/quail/releases>`_, which is pre-built. However, if you want to customize your build or use the `dev` branch of the project, you will need to use the following tools to build the project.
+For most purposes, you can simply `download the latest release of Quail <https://github.com/quailjs/quail/releases>`_, which is pre-built. However, if you want to customize your build or use the `dev` branch of the project, you will need to use the following tools to build the project.
 
 Quail is built using `Grunt <http://gruntjs.com/>`_ and `Bower <http://bower.io>`_, and hence requires having `Node.js <http://nodejs.org>`_ installed on your machine. Once you check out the code, follow the below commands:
 

--- a/docs/server-scanning.rst
+++ b/docs/server-scanning.rst
@@ -3,6 +3,6 @@ Scanning other websites with QUAIL
 
 Since QUAIL is now a jQuery plugin, it's no longer possible to run it natively in PHP. If you would like to scan other sites (without, say, getting your own javascript on their page a-la Google Analytics), then you'll need to run JavaScript on your backend.
 
-QUAIL already does this sort of thing in our continuous integration service on `Travis.org <https://travis-ci.org/kevee/quail/builds/7219577>`_ using `PhantomJS <http://phantomjs.org/>`_. PhantomJS is a full browser implementation that can do JavaScript tests and basically works like a browser.
+QUAIL already does this sort of thing in our continuous integration service on `Travis.org <https://travis-ci.org/quailjs/quail/builds/7219577>`_ using `PhantomJS <http://phantomjs.org/>`_. PhantomJS is a full browser implementation that can do JavaScript tests and basically works like a browser.
 
 Others have used QUAIL in combination with `Cheerio for NodeJS <https://github.com/MatthewMueller/cheerio>`_. Cheerio is an implementation of jQuery for NodeJS; however, certain tests that work with user interactions or JavaScript events will not work.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/kevee/quail.git"
+    "url": "git://github.com/quailjs/quail.git"
   },
   "main": "./quail.js",
   "bin": {

--- a/quail.json
+++ b/quail.json
@@ -3,17 +3,17 @@
   "title": "Quail",
   "description": "Accessibility testing in the browser and on the server.",
   "version": "2.1.0",
-  "homepage": "https://github.com/kevee/quail",
+  "homepage": "https://github.com/quailjs/quail",
   "author": {
     "name": "Kevin Miller",
     "email": "kemiller@csumb.edu"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/kevee/quail.git"
+    "url": "git://github.com/quailjs/quail.git"
   },
   "bugs": {
-    "url": "https://github.com/kevee/quail/issues"
+    "url": "https://github.com/quailjs/quail/issues"
   },
   "licenses": [
     {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -281,7 +281,7 @@ var quail = {
   },
 
   /**
-   * Read more about this function here: https://github.com/kevee/quail/wiki/Layout-versus-data-tables
+   * Read more about this function here: https://github.com/quailjs/quail/wiki/Layout-versus-data-tables
    */
   isDataTable : function(table) {
     // If there are less than three rows, why do a table?

--- a/test/testrunner.js
+++ b/test/testrunner.js
@@ -2,7 +2,7 @@
  * The test runner will take a properly-formatted page and
  * run accessibility tests against it. To learn more about how to use
  * the test runner, read the wiki at:
- * https://github.com/kevee/quail/wiki/Writing-unit-tests-and-testing-accessibility-tests
+ * https://github.com/quailjs/quail/wiki/Writing-unit-tests-and-testing-accessibility-tests
  */
 
 


### PR DESCRIPTION
Hello. I noticed that this repository still has references to `kevee/quail`, despite being moved to `quailjs/quail`, so I replaced them for you in this pull request. Using the old URL could be confusing and inefficient, and is also causing a 404 error when https://travis-ci.org/kevee/quail is visited.