### PR TITLE
Remove .jshintrc from ignore list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "2.1.0",
   "main": "dist/*",
   "ignore": [
-    ".jshintrc",
     "**/*.txt"
   ],
   "dependencies": {


### PR DESCRIPTION
Dev branch fails to build when installed using bower (eg: `bower install quailjs/quail#dev`)

Error occurs when jshint targets try to read .jshintrc, (it's path is explicitly defined in the gruntfile, so it always tries to open it)

Since bower is told to ignore .jshintrc when copying the repo, the file doesn't exist and therefore build fails