### PR TITLE
Pulling color apart

### DIFF
--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -2,8 +2,8 @@
  * Test callback for color tests. This handles both WAI and WCAG
  * color contrast/luminosity.
  */
-quail.components.color = function(quail, test, Case, options) {
-  var colors = {
+quail.components.color = {
+  colors: {
     cache: {},
     /**
      * Returns the lumosity of a given foreground and background object,
@@ -161,7 +161,7 @@ quail.components.color = function(quail, test, Case, options) {
 
       element.parents().each(function(){
         var pcolor = $(this).css('background-color');
-        if (colors.hasBackgroundColor(pcolor)) {
+        if (quail.components.color.colors.hasBackgroundColor(pcolor)) {
           return self.cache[cacheKey] = pcolor;
         }
       });
@@ -423,25 +423,27 @@ quail.components.color = function(quail, test, Case, options) {
      * Get first element behind current with a background color.
      */
     getBehindElementBackgroundColor: function(element) {
-      return colors.traverseVisualTreeForBackground(element, 'background-color');
+      return quail.components.color.colors.traverseVisualTreeForBackground(element, 'background-color');
     },
 
     /**
      * Get first element behind current with a background gradient.
      */
     getBehindElementBackgroundGradient: function(element) {
-      return colors.traverseVisualTreeForBackground(element, 'background-gradient');
+      return quail.components.color.colors.traverseVisualTreeForBackground(element, 'background-gradient');
     },
 
     /**
      * Get first element behind current with a background image.
      */
     getBehindElementBackgroundImage: function(element) {
-      return colors.traverseVisualTreeForBackground(element, 'background-image');
+      return quail.components.color.colors.traverseVisualTreeForBackground(element, 'background-image');
     }
-  };
-
-  var buildCase = function (element, status, id, message) {
+  },
+  /**
+   *
+   */
+  buildCase: function (test, Case, element, status, id, message) {
     test.add(Case({
       element: element,
       expected: (function (element, id) {
@@ -450,8 +452,11 @@ quail.components.color = function(quail, test, Case, options) {
       message: message,
       status: status
     }));
-  };
-  function testCandidates (textNode) {
+  },
+  /**
+   *
+   */
+  testCandidates: function (textNode, test, Case, options) {
     // We want a tag, not just the text node.
     var element = textNode.parentNode;
     var $this = $(element);
@@ -472,7 +477,7 @@ quail.components.color = function(quail, test, Case, options) {
 
     // Bail out if the text is not readable.
     if (quail.isUnreadable($this.text())) {
-      buildCase(element, 'cantTell', '', 'The text cannot be processed');
+      quail.components.color.buildCase(test, Case, element, 'cantTell', '', 'The text cannot be processed');
       return;
     }
 
@@ -481,35 +486,35 @@ quail.components.color = function(quail, test, Case, options) {
     // Check text and background color using DOM.
     id = 'colorFontContrast';
     // Build a case.
-    if ((algorithm === 'wcag' && !colors.passesWCAG($this)) ||
-    (algorithm === 'wai' && !colors.passesWAI($this))) {
-      buildCase(element, 'failed', id, 'The font contrast of the text impairs readability');
+    if ((algorithm === 'wcag' && !quail.components.color.colors.passesWCAG($this)) ||
+    (algorithm === 'wai' && !quail.components.color.colors.passesWAI($this))) {
+      quail.components.color.buildCase(test, Case, element, 'failed', id, 'The font contrast of the text impairs readability');
     }
     else {
-      buildCase(element, 'passed', id, 'The font contrast of the text is sufficient for readability');
+      quail.components.color.buildCase(test, Case, element, 'passed', id, 'The font contrast of the text is sufficient for readability');
     }
 
     // Check text and background using element behind current element.
     var backgroundColorBehind;
     // The option element is problematic.
     if (!$this.is('option')) {
-      backgroundColorBehind = colors.getBehindElementBackgroundColor($this);
+      backgroundColorBehind = quail.components.color.colors.getBehindElementBackgroundColor($this);
     }
     if (backgroundColorBehind) {
       id = 'colorElementBehindContrast';
-      failedWCAGColorTest = !colors.passesWCAGColor($this, colors.getColor($this, 'foreground'), backgroundColorBehind);
-      failedWAIColorTest = !colors.passesWAIColor(colors.getColor($this, 'foreground'), backgroundColorBehind);
+      failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), backgroundColorBehind);
+      failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), backgroundColorBehind);
       // Build a case.
       if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
-        buildCase(element, 'failed', id, 'The element behind this element makes the text unreadable');
+        quail.components.color.buildCase(test, Case, element, 'failed', id, 'The element behind this element makes the text unreadable');
       }
       else {
-        buildCase(element, 'passed', id, 'The element behind this element does not affect readability');
+        quail.components.color.buildCase(test, Case, element, 'passed', id, 'The element behind this element does not affect readability');
       }
     }
 
     // Check if there's a backgroundImage using DOM.
-    var backgroundImage = colors.getBackgroundImage($this);
+    var backgroundImage = quail.components.color.colors.getBackgroundImage($this);
     if (backgroundImage) {
       img = document.createElement('img');
       img.crossOrigin = "Anonymous";
@@ -517,20 +522,20 @@ quail.components.color = function(quail, test, Case, options) {
       // before information about it is available to the DOM.
       img.onload = function () {
         var id = 'colorBackgroundImageContrast';
-        var averageColorBackgroundImage = colors.getAverageRGB(img);
-        var failedWCAGColorTest = !colors.passesWCAGColor($this, colors.getColor($this, 'foreground'), averageColorBackgroundImage);
-        var failedWAIColorTest = !colors.passesWAIColor(colors.getColor($this, 'foreground'), averageColorBackgroundImage);
+        var averageColorBackgroundImage = quail.components.color.colors.getAverageRGB(img);
+        var failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), averageColorBackgroundImage);
+        var failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), averageColorBackgroundImage);
         // Build a case.
         if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
-          buildCase(element, 'failed', id, 'The element\'s background image makes the text unreadable');
+          quail.components.color.buildCase(test, Case, element, 'failed', id, 'The element\'s background image makes the text unreadable');
         }
         else {
-          buildCase(element, 'passed', id, 'The element\'s background image does not affect readability');
+          quail.components.color.buildCase(test, Case, element, 'passed', id, 'The element\'s background image does not affect readability');
         }
       };
       img.onerror = img.onabort = function () {
         var id = 'colorBackgroundImageContrast';
-        buildCase(element, 'cantTell', id, 'The element\'s background image could not be loaded (' + backgroundImage + ')');
+        quail.components.color.buildCase(test, Case, element, 'cantTell', id, 'The element\'s background image could not be loaded (' + backgroundImage + ')');
       };
       // Load the image.
       img.src = backgroundImage;
@@ -540,7 +545,7 @@ quail.components.color = function(quail, test, Case, options) {
     var behindBackgroundImage;
     // The option element is problematic.
     if (!$this.is('option')) {
-      behindBackgroundImage = colors.getBehindElementBackgroundImage($this);
+      behindBackgroundImage = quail.components.color.colors.getBehindElementBackgroundImage($this);
     }
     if (behindBackgroundImage) {
       img = document.createElement('img');
@@ -550,32 +555,32 @@ quail.components.color = function(quail, test, Case, options) {
       img.onload = function () {
         var id = 'colorElementBehindBackgroundImageContrast';
         // Get average color of the background image.
-        var averageColorBehindBackgroundImage = colors.getAverageRGB(img);
-        var failedWCAGColorTest = !colors.passesWCAGColor($this, colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
-        var failedWAIColorTest = !colors.passesWAIColor(colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
+        var averageColorBehindBackgroundImage = quail.components.color.colors.getAverageRGB(img);
+        var failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
+        var failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
         if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
-          buildCase(element, 'failed', id, 'The background image of the element behind this element makes the text unreadable');
+          quail.components.color.buildCase(test, Case, element, 'failed', id, 'The background image of the element behind this element makes the text unreadable');
         }
         else {
-          buildCase(element, 'passed', id, 'The background image of the element behind this element does not affect readability');
+          quail.components.color.buildCase(test, Case, element, 'passed', id, 'The background image of the element behind this element does not affect readability');
         }
       };
       img.onerror = img.onabort = function () {
         var id = 'colorElementBehindBackgroundImageContrast';
-        buildCase(element, 'cantTell', id, 'The background image of the element behind this element could not be loaded (' + behindBackgroundImage + ')');
+        quail.components.color.buildCase(test, Case, element, 'cantTell', id, 'The background image of the element behind this element could not be loaded (' + behindBackgroundImage + ')');
       };
       // Load the image.
       img.src = behindBackgroundImage;
     }
 
     // Check if there's a background gradient using DOM.
-    var backgroundGradientColors = colors.getBackgroundGradient($this);
+    var backgroundGradientColors = quail.components.color.colors.getBackgroundGradient($this);
     if (backgroundGradientColors) {
       id = 'colorBackgroundGradientContrast';
       // Convert colors to hex notation.
       for (i = 0; i < backgroundGradientColors.length; i++) {
         if (backgroundGradientColors[i].substr(0, 3) === 'rgb') {
-          backgroundGradientColors[i] = colors.colorToHex(backgroundGradientColors[i]);
+          backgroundGradientColors[i] = quail.components.color.colors.colorToHex(backgroundGradientColors[i]);
         }
       }
 
@@ -589,17 +594,17 @@ quail.components.color = function(quail, test, Case, options) {
       // Check each color.
       failureFound = false;
       for (i = 0; !failureFound && i < numberOfSamples; i++) {
-        failedWCAGColorTest = !colors.passesWCAGColor($this, colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
-        failedWAIColorTest = !colors.passesWAIColor(colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
+        failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
+        failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
         if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
-          buildCase(element, 'failed', id, 'The background gradient makes the text unreadable');
+          quail.components.color.buildCase(test, Case, element, 'failed', id, 'The background gradient makes the text unreadable');
           failureFound = true;
         }
       }
 
       // If no failure was found, the element passes for this case type.
       if (!failureFound) {
-        buildCase(element, 'passed', id, 'The background gradient does not affect readability');
+        quail.components.color.buildCase(test, Case, element, 'passed', id, 'The background gradient does not affect readability');
       }
     }
 
@@ -607,14 +612,14 @@ quail.components.color = function(quail, test, Case, options) {
     var behindGradientColors;
     // The option element is problematic.
     if (!$this.is('option')) {
-      behindGradientColors = colors.getBehindElementBackgroundGradient($this);
+      behindGradientColors = quail.components.color.colors.getBehindElementBackgroundGradient($this);
     }
     if (behindGradientColors) {
       id = 'colorElementBehindBackgroundGradientContrast';
       // Convert colors to hex notation.
       for (i = 0; i < behindGradientColors.length; i++) {
         if (behindGradientColors[i].substr(0, 3) === 'rgb') {
-          behindGradientColors[i] = colors.colorToHex(behindGradientColors[i]);
+          behindGradientColors[i] = quail.components.color.colors.colorToHex(behindGradientColors[i]);
         }
       }
 
@@ -627,77 +632,56 @@ quail.components.color = function(quail, test, Case, options) {
       // Check each color.
       failureFound = false;
       for (i = 0; !failureFound && i < numberOfSamples; i++) {
-        failedWCAGColorTest = !colors.passesWCAGColor($this, colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
-        failedWAIColorTest = !colors.passesWAIColor(colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
+        failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
+        failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), '#' + rainbow.colourAt(i));
         if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
-          buildCase(element, 'failed', id, 'The background gradient of the element behind this element makes the text unreadable');
+          quail.components.color.buildCase(test, Case, element, 'failed', id, 'The background gradient of the element behind this element makes the text unreadable');
           failureFound = true;
         }
       }
 
       // If no failure was found, the element passes for this case type.
       if (!failureFound) {
-        buildCase(element, 'passed', id, 'The background gradient of the element behind this element does not affect readability');
+        quail.components.color.buildCase(test, Case, element, 'passed', id, 'The background gradient of the element behind this element does not affect readability');
       }
     }
-  }
-
-  test.get('$scope').each(function () {
-    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
-    var nodes = [];
-    var text = textnodes.iterateNext();
-    if (!text) {
-      buildCase(null, 'inapplicable', '', 'There is no text to evaluate');
-    }
-    else {
-      // Loop has to be separated. If we try to iterate and rund testCandidates
-      // the xpath thing will crash because document is being modified.
-      while (text) {
-        nodes.push(text);
-        text = textnodes.iterateNext();
-      }
-      nodes.forEach(function (textNode) {
-        testCandidates(textNode);
-      });
-    }
-  });
-};
-
-/**
- * For the color test, if any case passes for a given element, then all the
- * cases for that element pass.
- */
-quail.components.color.postInvoke = function (test) {
-  var passed = {};
-  var groupsBySelector = test.groupCasesBySelector();
-
+  },
   /**
-   * Determine the length of an object.
-   *
-   * @param object obj
-   *   The object whose size will be determined.
-   *
-   * @return number
-   *   The size of the object determined by the number of keys.
+   * For the color test, if any case passes for a given element, then all the
+   * cases for that element pass.
    */
-  function size (obj) {
-    return Object.keys(obj).length;
-  }
+  postInvoke: function (test) {
+    var passed = {};
+    var groupsBySelector = test.groupCasesBySelector();
 
-  // Go through each selector group.
-  var nub = '';
-  for (var selector in groupsBySelector) {
-    if (groupsBySelector.hasOwnProperty(selector)) {
-      var cases = groupsBySelector[selector];
-      cases.each(function (index, _case) {
-        if (_case.get('status') === passed) {
-          // This can just be an empty string. We only need the passed hash
-          // to contain keys, not values.
-          passed[selector] = nub;
-        }
-      });
+    /**
+     * Determine the length of an object.
+     *
+     * @param object obj
+     *   The object whose size will be determined.
+     *
+     * @return number
+     *   The size of the object determined by the number of keys.
+     */
+    function size (obj) {
+      return Object.keys(obj).length;
     }
-  }
 
-  return size(passed) === size(groupsBySelector);
+    // Go through each selector group.
+    var nub = '';
+    for (var selector in groupsBySelector) {
+      if (groupsBySelector.hasOwnProperty(selector)) {
+        var cases = groupsBySelector[selector];
+        cases.each(function (index, _case) {
+          if (_case.get('status') === passed) {
+            // This can just be an empty string. We only need the passed hash
+            // to contain keys, not values.
+            passed[selector] = nub;
+          }
+        });
+      }
+    }
+
+    return size(passed) === size(groupsBySelector);
+  }
 };

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -483,6 +483,9 @@ quail.components.color = {
 
     var img, i, rainbow, numberOfSamples;
 
+    /**
+     *
+     */
     function colorFontContrast () {
       // Check text and background color using DOM.
       // Build a case.
@@ -495,32 +498,40 @@ quail.components.color = {
       }
     }
 
+    /**
+     *
+     */
+    function colorElementBehindContrast () {
+      // Check text and background using element behind current element.
+      var backgroundColorBehind;
+      // The option element is problematic.
+      if (!$this.is('option')) {
+        backgroundColorBehind = quail.components.color.colors.getBehindElementBackgroundColor($this);
+      }
+      if (backgroundColorBehind) {
+        id = 'colorElementBehindContrast';
+        failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), backgroundColorBehind);
+        failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), backgroundColorBehind);
+        // Build a case.
+        if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
+          quail.components.color.buildCase(test, Case, element, 'failed', id, 'The element behind this element makes the text unreadable');
+        }
+        else {
+          quail.components.color.buildCase(test, Case, element, 'passed', id, 'The element behind this element does not affect readability');
+        }
+      }
+    }
+
     // Switch on the type of color test to run.
     switch (id) {
     case 'colorFontContrast':
       colorFontContrast();
       break;
+    case 'colorElementBehindContrast':
+      colorElementBehindContrast();
+      break;
     }
     return;
-
-    // Check text and background using element behind current element.
-    var backgroundColorBehind;
-    // The option element is problematic.
-    if (!$this.is('option')) {
-      backgroundColorBehind = quail.components.color.colors.getBehindElementBackgroundColor($this);
-    }
-    if (backgroundColorBehind) {
-      id = 'colorElementBehindContrast';
-      failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), backgroundColorBehind);
-      failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), backgroundColorBehind);
-      // Build a case.
-      if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
-        quail.components.color.buildCase(test, Case, element, 'failed', id, 'The element behind this element makes the text unreadable');
-      }
-      else {
-        quail.components.color.buildCase(test, Case, element, 'passed', id, 'The element behind this element does not affect readability');
-      }
-    }
 
     // Check if there's a backgroundImage using DOM.
     var backgroundImage = quail.components.color.colors.getBackgroundImage($this);

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -456,12 +456,12 @@ quail.components.color = {
   /**
    *
    */
-  testCandidates: function (textNode, test, Case, options) {
+  testCandidates: function (id, textNode, test, Case, options) {
     // We want a tag, not just the text node.
     var element = textNode.parentNode;
     var $this = $(element);
     var algorithm = options.algorithm;
-    var id, failureFound, failedWCAGColorTest, failedWAIColorTest;
+    var failureFound, failedWCAGColorTest, failedWAIColorTest;
     // The nodeType of the element must be 1. Nodes of type 1 implement the Element
     // interface which is required of the first argument passed to window.getComputedStyle.
     // Failure to pass an Element <node> to window.getComputedStyle will raised an exception
@@ -483,16 +483,25 @@ quail.components.color = {
 
     var img, i, rainbow, numberOfSamples;
 
-    // Check text and background color using DOM.
-    id = 'colorFontContrast';
-    // Build a case.
-    if ((algorithm === 'wcag' && !quail.components.color.colors.passesWCAG($this)) ||
-    (algorithm === 'wai' && !quail.components.color.colors.passesWAI($this))) {
-      quail.components.color.buildCase(test, Case, element, 'failed', id, 'The font contrast of the text impairs readability');
+    function colorFontContrast () {
+      // Check text and background color using DOM.
+      // Build a case.
+      if ((algorithm === 'wcag' && !quail.components.color.colors.passesWCAG($this)) ||
+      (algorithm === 'wai' && !quail.components.color.colors.passesWAI($this))) {
+        quail.components.color.buildCase(test, Case, element, 'failed', id, 'The font contrast of the text impairs readability');
+      }
+      else {
+        quail.components.color.buildCase(test, Case, element, 'passed', id, 'The font contrast of the text is sufficient for readability');
+      }
     }
-    else {
-      quail.components.color.buildCase(test, Case, element, 'passed', id, 'The font contrast of the text is sufficient for readability');
+
+    // Switch on the type of color test to run.
+    switch (id) {
+    case 'colorFontContrast':
+      colorFontContrast();
+      break;
     }
+    return;
 
     // Check text and background using element behind current element.
     var backgroundColorBehind;

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -555,6 +555,43 @@ quail.components.color = {
       }
     }
 
+    /**
+     *
+     */
+    function colorElementBehindBackgroundImageContrast () {
+      // Check if there's a backgroundImage using element behind current element.
+      var behindBackgroundImage;
+      // The option element is problematic.
+      if (!$this.is('option')) {
+        behindBackgroundImage = quail.components.color.colors.getBehindElementBackgroundImage($this);
+      }
+      if (behindBackgroundImage) {
+        img = document.createElement('img');
+        img.crossOrigin = "Anonymous";
+        // The image must first load before information about it is available to
+        // the DOM.
+        img.onload = function () {
+          var id = 'colorElementBehindBackgroundImageContrast';
+          // Get average color of the background image.
+          var averageColorBehindBackgroundImage = quail.components.color.colors.getAverageRGB(img);
+          var failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
+          var failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
+          if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
+            quail.components.color.buildCase(test, Case, element, 'failed', id, 'The background image of the element behind this element makes the text unreadable');
+          }
+          else {
+            quail.components.color.buildCase(test, Case, element, 'passed', id, 'The background image of the element behind this element does not affect readability');
+          }
+        };
+        img.onerror = img.onabort = function () {
+          var id = 'colorElementBehindBackgroundImageContrast';
+          quail.components.color.buildCase(test, Case, element, 'cantTell', id, 'The background image of the element behind this element could not be loaded (' + behindBackgroundImage + ')');
+        };
+        // Load the image.
+        img.src = behindBackgroundImage;
+      }
+    }
+
     // Switch on the type of color test to run.
     switch (id) {
     case 'colorFontContrast':
@@ -566,40 +603,11 @@ quail.components.color = {
     case 'colorBackgroundImageContrast':
       colorBackgroundImageContrast();
       break;
+    case 'colorElementBehindBackgroundImageContrast':
+      colorElementBehindBackgroundImageContrast();
+      break;
     }
     return;
-
-    // Check if there's a backgroundImage using element behind current element.
-    var behindBackgroundImage;
-    // The option element is problematic.
-    if (!$this.is('option')) {
-      behindBackgroundImage = quail.components.color.colors.getBehindElementBackgroundImage($this);
-    }
-    if (behindBackgroundImage) {
-      img = document.createElement('img');
-      img.crossOrigin = "Anonymous";
-      // The image must first load before information about it is available to
-      // the DOM.
-      img.onload = function () {
-        var id = 'colorElementBehindBackgroundImageContrast';
-        // Get average color of the background image.
-        var averageColorBehindBackgroundImage = quail.components.color.colors.getAverageRGB(img);
-        var failedWCAGColorTest = !quail.components.color.colors.passesWCAGColor($this, quail.components.color.colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
-        var failedWAIColorTest = !quail.components.color.colors.passesWAIColor(quail.components.color.colors.getColor($this, 'foreground'), averageColorBehindBackgroundImage);
-        if ((algorithm === 'wcag' && failedWCAGColorTest) || (algorithm === 'wai' && failedWAIColorTest)) {
-          quail.components.color.buildCase(test, Case, element, 'failed', id, 'The background image of the element behind this element makes the text unreadable');
-        }
-        else {
-          quail.components.color.buildCase(test, Case, element, 'passed', id, 'The background image of the element behind this element does not affect readability');
-        }
-      };
-      img.onerror = img.onabort = function () {
-        var id = 'colorElementBehindBackgroundImageContrast';
-        quail.components.color.buildCase(test, Case, element, 'cantTell', id, 'The background image of the element behind this element could not be loaded (' + behindBackgroundImage + ')');
-      };
-      // Load the image.
-      img.src = behindBackgroundImage;
-    }
 
     // Check if there's a background gradient using DOM.
     var backgroundGradientColors = quail.components.color.colors.getBackgroundGradient($this);

--- a/src/js/custom/colorBackgroundGradientContrast.js
+++ b/src/js/custom/colorBackgroundGradientContrast.js
@@ -1,0 +1,21 @@
+quail.colorBackgroundGradientContrast = function (quail, test, Case, options) {
+  test.get('$scope').each(function () {
+    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var text = textnodes.iterateNext();
+    if (!text) {
+      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+    else {
+      // Loop has to be separated. If we try to iterate and rund testCandidates
+      // the xpath thing will crash because document is being modified.
+      while (text) {
+        nodes.push(text);
+        text = textnodes.iterateNext();
+      }
+      nodes.forEach(function (textNode) {
+        quail.components.color.testCandidates('colorBackgroundGradientContrast', textNode, test, Case, options);
+      });
+    }
+  });
+};

--- a/src/js/custom/colorBackgroundImageContrast.js
+++ b/src/js/custom/colorBackgroundImageContrast.js
@@ -1,0 +1,21 @@
+quail.colorBackgroundImageContrast = function (quail, test, Case, options) {
+  test.get('$scope').each(function () {
+    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var text = textnodes.iterateNext();
+    if (!text) {
+      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+    else {
+      // Loop has to be separated. If we try to iterate and rund testCandidates
+      // the xpath thing will crash because document is being modified.
+      while (text) {
+        nodes.push(text);
+        text = textnodes.iterateNext();
+      }
+      nodes.forEach(function (textNode) {
+        quail.components.color.testCandidates('colorBackgroundImageContrast', textNode, test, Case, options);
+      });
+    }
+  });
+};

--- a/src/js/custom/colorElementBehindBackgroundGradientContrast.js
+++ b/src/js/custom/colorElementBehindBackgroundGradientContrast.js
@@ -1,0 +1,21 @@
+quail.colorElementBehindBackgroundGradientContrast = function (quail, test, Case, options) {
+  test.get('$scope').each(function () {
+    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var text = textnodes.iterateNext();
+    if (!text) {
+      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+    else {
+      // Loop has to be separated. If we try to iterate and rund testCandidates
+      // the xpath thing will crash because document is being modified.
+      while (text) {
+        nodes.push(text);
+        text = textnodes.iterateNext();
+      }
+      nodes.forEach(function (textNode) {
+        quail.components.color.testCandidates('colorElementBehindBackgroundGradientContrast', textNode, test, Case, options);
+      });
+    }
+  });
+};

--- a/src/js/custom/colorElementBehindBackgroundImageContrast.js
+++ b/src/js/custom/colorElementBehindBackgroundImageContrast.js
@@ -1,0 +1,21 @@
+quail.colorElementBehindBackgroundImageContrast = function (quail, test, Case, options) {
+  test.get('$scope').each(function () {
+    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var text = textnodes.iterateNext();
+    if (!text) {
+      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+    else {
+      // Loop has to be separated. If we try to iterate and rund testCandidates
+      // the xpath thing will crash because document is being modified.
+      while (text) {
+        nodes.push(text);
+        text = textnodes.iterateNext();
+      }
+      nodes.forEach(function (textNode) {
+        quail.components.color.testCandidates('colorElementBehindBackgroundImageContrast', textNode, test, Case, options);
+      });
+    }
+  });
+};

--- a/src/js/custom/colorElementBehindContrast.js
+++ b/src/js/custom/colorElementBehindContrast.js
@@ -1,0 +1,21 @@
+quail.colorElementBehindContrast = function (quail, test, Case, options) {
+  test.get('$scope').each(function () {
+    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var text = textnodes.iterateNext();
+    if (!text) {
+      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+    else {
+      // Loop has to be separated. If we try to iterate and rund testCandidates
+      // the xpath thing will crash because document is being modified.
+      while (text) {
+        nodes.push(text);
+        text = textnodes.iterateNext();
+      }
+      nodes.forEach(function (textNode) {
+        quail.components.color.testCandidates('colorElementBehindContrast', textNode, test, Case, options);
+      });
+    }
+  });
+};

--- a/src/js/custom/colorFontContrast.js
+++ b/src/js/custom/colorFontContrast.js
@@ -14,7 +14,7 @@ quail.colorFontContrast = function (quail, test, Case, options) {
         text = textnodes.iterateNext();
       }
       nodes.forEach(function (textNode) {
-        quail.components.color.testCandidates(textNode, test, Case, options);
+        quail.components.color.testCandidates('colorFontContrast', textNode, test, Case, options);
       });
     }
   });

--- a/src/js/custom/colorFontContrast.js
+++ b/src/js/custom/colorFontContrast.js
@@ -1,4 +1,4 @@
-quail.cssTextHasContrast = function (quail, test, Case, options) {
+quail.colorFontContrast = function (quail, test, Case, options) {
   test.get('$scope').each(function () {
     var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
     var nodes = [];

--- a/src/js/custom/cssTextHasContrast.js
+++ b/src/js/custom/cssTextHasContrast.js
@@ -1,0 +1,21 @@
+quail.cssTextHasContrast = function (quail, test, Case, options) {
+  test.get('$scope').each(function () {
+    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var text = textnodes.iterateNext();
+    if (!text) {
+      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+    else {
+      // Loop has to be separated. If we try to iterate and rund testCandidates
+      // the xpath thing will crash because document is being modified.
+      while (text) {
+        nodes.push(text);
+        text = textnodes.iterateNext();
+      }
+      nodes.forEach(function (textNode) {
+        quail.components.color.testCandidates(textNode, test, Case, options);
+      });
+    }
+  });
+};

--- a/src/js/lib/Test.js
+++ b/src/js/lib/Test.js
@@ -93,6 +93,8 @@ quail.lib.Test = (function () {
       if (this.attributes.complete) {
         throw new Error('The test ' + this.get('name') + ' has already been run.');
       }
+
+      debugger;
       var type = this.get('type');
       var options = this.get('options') || {};
       var callback = this.get('callback');

--- a/src/js/lib/Test.js
+++ b/src/js/lib/Test.js
@@ -94,7 +94,6 @@ quail.lib.Test = (function () {
         throw new Error('The test ' + this.get('name') + ' has already been run.');
       }
 
-      debugger;
       var type = this.get('type');
       var options = this.get('options') || {};
       var callback = this.get('callback');

--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -882,6 +882,28 @@ colorElementBehindContrast:
     algorithm: "wcag"
     selector: "*"
     gradientSampleMultiplier: 3
+colorBackgroundImageContrast:
+  type: "custom"
+  testability: 1
+  title:
+    en: "All elements should have appropriate color contrast"
+    nl: "Alle elementen moeten een toepasselijk kleurcontract hebben"
+  description:
+    en: "For users who have color blindness, all text or other elements should have a color contrast of 5:1."
+    nl: "Voor gebruikers met kleurenblindheid moeten alle tekst- en andere elementen een kleurcontrast hebben van 5:1."
+  guidelines:
+    wcag:
+      1.4.3:
+        techniques:
+          - "G18"
+  tags:
+    - "color"
+  callback:
+    - "colorBackgroundImageContrast"
+  options:
+    algorithm: "wcag"
+    selector: "*"
+    gradientSampleMultiplier: 3
 definitionListsAreUsed:
   type: "custom"
   testability: 0.5

--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -926,6 +926,28 @@ colorElementBehindBackgroundImageContrast:
     algorithm: "wcag"
     selector: "*"
     gradientSampleMultiplier: 3
+colorBackgroundGradientContrast:
+  type: "custom"
+  testability: 1
+  title:
+    en: "All elements should have appropriate color contrast"
+    nl: "Alle elementen moeten een toepasselijk kleurcontract hebben"
+  description:
+    en: "For users who have color blindness, all text or other elements should have a color contrast of 5:1."
+    nl: "Voor gebruikers met kleurenblindheid moeten alle tekst- en andere elementen een kleurcontrast hebben van 5:1."
+  guidelines:
+    wcag:
+      1.4.3:
+        techniques:
+          - "G18"
+  tags:
+    - "color"
+  callback:
+    - "colorBackgroundGradientContrast"
+  options:
+    algorithm: "wcag"
+    selector: "*"
+    gradientSampleMultiplier: 3
 definitionListsAreUsed:
   type: "custom"
   testability: 0.5

--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -948,6 +948,28 @@ colorBackgroundGradientContrast:
     algorithm: "wcag"
     selector: "*"
     gradientSampleMultiplier: 3
+colorElementBehindBackgroundGradientContrast:
+  type: "custom"
+  testability: 1
+  title:
+    en: "All elements should have appropriate color contrast"
+    nl: "Alle elementen moeten een toepasselijk kleurcontract hebben"
+  description:
+    en: "For users who have color blindness, all text or other elements should have a color contrast of 5:1."
+    nl: "Voor gebruikers met kleurenblindheid moeten alle tekst- en andere elementen een kleurcontrast hebben van 5:1."
+  guidelines:
+    wcag:
+      1.4.3:
+        techniques:
+          - "G18"
+  tags:
+    - "color"
+  callback:
+    - "colorElementBehindBackgroundGradientContrast"
+  options:
+    algorithm: "wcag"
+    selector: "*"
+    gradientSampleMultiplier: 3
 definitionListsAreUsed:
   type: "custom"
   testability: 0.5

--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -860,6 +860,28 @@ colorFontContrast:
     algorithm: "wcag"
     selector: "*"
     gradientSampleMultiplier: 3
+colorElementBehindContrast:
+  type: "custom"
+  testability: 1
+  title:
+    en: "All elements should have appropriate color contrast"
+    nl: "Alle elementen moeten een toepasselijk kleurcontract hebben"
+  description:
+    en: "For users who have color blindness, all text or other elements should have a color contrast of 5:1."
+    nl: "Voor gebruikers met kleurenblindheid moeten alle tekst- en andere elementen een kleurcontrast hebben van 5:1."
+  guidelines:
+    wcag:
+      1.4.3:
+        techniques:
+          - "G18"
+  tags:
+    - "color"
+  callback:
+    - "colorElementBehindContrast"
+  options:
+    algorithm: "wcag"
+    selector: "*"
+    gradientSampleMultiplier: 3
 definitionListsAreUsed:
   type: "custom"
   testability: 0.5

--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -904,6 +904,28 @@ colorBackgroundImageContrast:
     algorithm: "wcag"
     selector: "*"
     gradientSampleMultiplier: 3
+colorElementBehindBackgroundImageContrast:
+  type: "custom"
+  testability: 1
+  title:
+    en: "All elements should have appropriate color contrast"
+    nl: "Alle elementen moeten een toepasselijk kleurcontract hebben"
+  description:
+    en: "For users who have color blindness, all text or other elements should have a color contrast of 5:1."
+    nl: "Voor gebruikers met kleurenblindheid moeten alle tekst- en andere elementen een kleurcontrast hebben van 5:1."
+  guidelines:
+    wcag:
+      1.4.3:
+        techniques:
+          - "G18"
+  tags:
+    - "color"
+  callback:
+    - "colorElementBehindBackgroundImageContrast"
+  options:
+    algorithm: "wcag"
+    selector: "*"
+    gradientSampleMultiplier: 3
 definitionListsAreUsed:
   type: "custom"
   testability: 0.5

--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -838,7 +838,7 @@ cssDocumentMakesSenseStyleTurnedOff:
     - "color"
   options:
     selector: "link[rel=stylesheet], stylesheet, *[style]"
-cssTextHasContrast:
+colorFontContrast:
   type: "custom"
   testability: 1
   title:
@@ -855,7 +855,7 @@ cssTextHasContrast:
   tags:
     - "color"
   callback:
-    - "cssTextHasContrast"
+    - "colorFontContrast"
   options:
     algorithm: "wcag"
     selector: "*"

--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -839,7 +839,7 @@ cssDocumentMakesSenseStyleTurnedOff:
   options:
     selector: "link[rel=stylesheet], stylesheet, *[style]"
 cssTextHasContrast:
-  type: "color"
+  type: "custom"
   testability: 1
   title:
     en: "All elements should have appropriate color contrast"
@@ -854,8 +854,8 @@ cssTextHasContrast:
           - "G18"
   tags:
     - "color"
-  components:
-    - "color"
+  callback:
+    - "cssTextHasContrast"
   options:
     algorithm: "wcag"
     selector: "*"

--- a/src/resources/wcag2.yml
+++ b/src/resources/wcag2.yml
@@ -168,6 +168,7 @@
         - colorBackgroundImageContrast
         - colorElementBehindBackgroundImageContrast
         - colorBackgroundGradientContrast
+        - colorElementBehindBackgroundGradientContrast
 1.4.4:
   id: "wcag20:visual-audio-contrast-scale"
   level: "wcag20:level_aa"

--- a/src/resources/wcag2.yml
+++ b/src/resources/wcag2.yml
@@ -164,6 +164,7 @@
       failed: failed
       tests:
         - colorFontContrast
+        - colorElementBehindContrast
 1.4.4:
   id: "wcag20:visual-audio-contrast-scale"
   level: "wcag20:level_aa"

--- a/src/resources/wcag2.yml
+++ b/src/resources/wcag2.yml
@@ -166,6 +166,7 @@
         - colorFontContrast
         - colorElementBehindContrast
         - colorBackgroundImageContrast
+        - colorElementBehindBackgroundImageContrast
 1.4.4:
   id: "wcag20:visual-audio-contrast-scale"
   level: "wcag20:level_aa"

--- a/src/resources/wcag2.yml
+++ b/src/resources/wcag2.yml
@@ -167,6 +167,7 @@
         - colorElementBehindContrast
         - colorBackgroundImageContrast
         - colorElementBehindBackgroundImageContrast
+        - colorBackgroundGradientContrast
 1.4.4:
   id: "wcag20:visual-audio-contrast-scale"
   level: "wcag20:level_aa"

--- a/src/resources/wcag2.yml
+++ b/src/resources/wcag2.yml
@@ -165,6 +165,7 @@
       tests:
         - colorFontContrast
         - colorElementBehindContrast
+        - colorBackgroundImageContrast
 1.4.4:
   id: "wcag20:visual-audio-contrast-scale"
   level: "wcag20:level_aa"

--- a/src/resources/wcag2.yml
+++ b/src/resources/wcag2.yml
@@ -163,7 +163,7 @@
     - passed: passed
       failed: failed
       tests:
-        - cssTextHasContrast
+        - colorFontContrast
 1.4.4:
   id: "wcag20:visual-audio-contrast-scale"
   level: "wcag20:level_aa"

--- a/test/accessibility-tests/colorBackgroundGradientContrast.html
+++ b/test/accessibility-tests/colorBackgroundGradientContrast.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+<head>
+  <title>colorBackgroundGradientContrast</title>
+  <style>
+    #test-1 p {
+      color: #fff;
+      padding: 10px;
+      background-image: linear-gradient(to bottom, #de88de, #98afd6);
+    }
+    #test-2 p {
+      color: #fff;
+      padding: 10px;
+      background-image: linear-gradient(to bottom, #610061, #032966);
+    }
+
+    #test-3 p {
+      color: #fff;
+      padding: 10px;
+      background-image: linear-gradient(to right, red, #f06d06, rgb(255, 255, 0), green);
+    }
+
+    #test-4 {
+      color: #fff;
+      padding: 10px;
+      background-image: radial-gradient(red, #f06d06, rgb(255, 255, 0), green);
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast" id="test-1">
+    <p>This test is not readable</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorBackgroundGradientContrast:pass" data-accessibility-test="colorBackgroundGradientContrast" id="test-2">
+    <p>This test is readable</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast" id="test-3">
+    <p>This test is not readable</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast" id="test-4">
+    <p>This test is not readable, but on screen it is</p>
+  </div>
+
+  <script src="../quail-testrunner.js"></script>
+</body>
+</html>

--- a/test/accessibility-tests/colorBackgroundImageContrast.html
+++ b/test/accessibility-tests/colorBackgroundImageContrast.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+  <title>colorBackgroundImageContrast</title>
+  <style>
+    #test-1 {
+      background-image: url('../assets/fish.gif');
+    }
+    #test-1 p {
+      color: #666;
+      font-size: 16px;
+      font-weight: 700;
+    }
+    #test-2 {
+      background-image: url('../assets/kids.jpg');
+    }
+    #test-2 p {
+      background: #000;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+    }
+    #test-3 {
+      background-image: url('../assets/doesnotexist.jpg');
+    }
+    #test-3 p {
+      background: #000;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+    }
+    #test-4 {
+      background-image: url('../assets/quail.png');
+    }
+    #test-4 p {
+      background: #000;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+  <div class="quail-test" data-expected="colorBackgroundImageContrast:fail" data-accessibility-test="colorBackgroundImageContrast" id="test-1">
+    <p>This test is not readable, thanks to the fish</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorBackgroundImageContrast:pass" data-accessibility-test="colorBackgroundImageContrast" id="test-2">
+    <p>This test is readable, thanks to the kids</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorBackgroundImageContrast:cantTell" data-accessibility-test="colorBackgroundImageContrast" id="test-3">
+    <p>This test is readable, non existing background</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorBackgroundImageContrast:pass" data-accessibility-test="colorBackgroundImageContrast" id="test-4">
+    <p>This test is readable, external image</p>
+  </div>
+
+  <script src="../quail-testrunner.js"></script>
+</body>
+</html>

--- a/test/accessibility-tests/colorElementBehindBackgroundGradientContrast.html
+++ b/test/accessibility-tests/colorElementBehindBackgroundGradientContrast.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+  <title>colorElementBehindBackgroundGradientContrast</title>
+  <style>
+    #test-1 {
+      color: #fff;
+      padding: 10px;
+      background-image: radial-gradient(red, #f06d06, rgb(255, 255, 0), green);
+      text-align: center;
+    }
+    #test-2 {
+      color: #000;
+      padding: 10px;
+      background-image: radial-gradient(red, #f06d06, rgb(255, 255, 0), green);
+      text-align: center;
+    }
+    #test-2 p {
+      background: #E9E9E9;
+    }
+    #test-3 {
+      position: relative;
+      padding: 0;
+    }
+    #test-3 .bck {
+      background-image: linear-gradient(to right, red, #f06d06, rgb(255, 255, 0), green);
+      height: 50px;
+      width: 100%;
+      position: absolute;
+    }
+    #test-3 .txt {
+      color: #666;
+      font-size: 16px;
+      font-weight: 700;
+      height: 18px;
+      position: relative;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="quail-test" data-expected="colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="colorElementBehindBackgroundGradientContrast" id="test-1">
+    <p>This test is not readable, but on screen it is</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorElementBehindBackgroundGradientContrast:pass" data-accessibility-test="colorElementBehindBackgroundGradientContrast" id="test-2">
+    <p>This test is readable, does not check the gradient since there's a background color.</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="colorElementBehindBackgroundGradientContrast" id="test-3">
+    <div class="bck"></div>
+    <p class="txt">This test is not readable.</p>
+  </div>
+
+  <script src="../quail-testrunner.js"></script>
+</body>
+</html>

--- a/test/accessibility-tests/colorElementBehindBackgroundImageContrast.html
+++ b/test/accessibility-tests/colorElementBehindBackgroundImageContrast.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+  <title>colorElementBehindBackgroundImageContrast</title>
+  <style>
+
+    #test-1 {
+      background-image: url('../assets/fish.gif');
+    }
+    #test-1 p {
+      color: #666;
+      font-size: 16px;
+      font-weight: 700;
+    }
+
+    #test-2 {
+      background-image: url('../assets/kids.jpg');
+    }
+    #test-2 p {
+      background: #000;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+    }
+
+    #test-3 {
+      position: relative;
+      padding: 0;
+    }
+    #test-3 .bck {
+      background-image: url('../assets/fish.gif');
+      height: 50px;
+      width: 100%;
+      position: absolute;
+    }
+    #test-3 .txt {
+      color: #666;
+      font-size: 16px;
+      font-weight: 700;
+      height: 50px;
+      position: relative;
+    }
+
+    #test-4 {
+      background-image: url('../assets/quail.png');
+    }
+    #test-4 p {
+      background: #000;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+    }
+
+  </style>
+</head>
+<body>
+
+  <div class="quail-test" data-expected="colorElementBehindBackgroundImageContrast:fail" data-accessibility-test="colorElementBehindBackgroundImageContrast" id="test-1">
+    <p>This test is not readable, thanks to the fish</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="colorElementBehindBackgroundImageContrast" id="test-2">
+    <p>This test is readable, thanks to the kids</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorElementBehindBackgroundImageContrast:fail" data-accessibility-test="colorElementBehindBackgroundImageContrast" id="test-3">
+    <div class="bck"></div>
+    <p class="txt">This test is not readable.</p>
+  </div>
+
+  <div class="quail-test" data-expected="colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="colorElementBehindBackgroundImageContrast" id="test-4">
+    <p>This test is readable, external image</p>
+  </div>
+
+  <script src="../quail-testrunner.js"></script>
+</body>
+</html>

--- a/test/accessibility-tests/colorElementBehindContrast.html
+++ b/test/accessibility-tests/colorElementBehindContrast.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+  <title>colorElementBehindContrast</title>
+  <style>
+    #test-1 {
+      background: #666;
+    }
+    #test-1 .txt {
+      color: #666;
+      font-size: 16px;
+      font-weight: 700;
+    }
+    #test-2 {
+      background: #fff;
+    }
+    #test-2 .txt {
+      color: #000;
+      font-size: 16px;
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+  <div class="quail-test" data-expected="colorElementBehindContrast:fail" data-accessibility-test="colorElementBehindContrast" id="test-1">
+    <div class="bck"></div>
+    <p class="txt">This test is not readable.</p>
+  </div>
+  <div class="quail-test" data-expected="colorElementBehindContrast:pass" data-accessibility-test="colorElementBehindContrast" id="test-2">
+    <div class="bck"></div>
+    <p class="txt">This test is readable.</p>
+  </div>
+  <script src="../quail-testrunner.js"></script>
+</body>
+</html>

--- a/test/accessibility-tests/colorFontContrast.html
+++ b/test/accessibility-tests/colorFontContrast.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-  <title>cssTextHasContrast</title>
+  <title>colorFontContrast</title>
   <style>
     #test-1 p {
       background: #E9E9E9;
@@ -165,82 +165,82 @@
   </style>
 </head>
 <body>
-  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-0">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-0">
     <p>This text is readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-1">
+  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="colorFontContrast" id="test-1">
     <p>This text is not readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-2">
+  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="colorFontContrast" id="test-2">
     <p>This text is not readable, even if it's huge and bold</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-3">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-3">
     <p>This test is readable.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-4">
+  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="colorFontContrast" id="test-4">
     <p>This test is not readable, only 16px and not bold</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-5">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-5">
     <p>This test is readable, 16px and bold</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-6">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-6">
     <p>This test is readable, 16px and font weight 700</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundImageContrast:fail|colorBackgroundImageContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-7">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundImageContrast:fail|colorBackgroundImageContrast:fail" data-accessibility-test="colorFontContrast" id="test-7">
     <p>This test is not readable, thanks to the fish</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:pass|colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-8">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:pass|colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="colorFontContrast" id="test-8">
     <p>This test is readable, thanks to the kids</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-9">
+  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-9">
     <p>This test is not readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-10">
+  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:pass" data-accessibility-test="colorFontContrast" id="test-10">
     <p>This test is readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-11">
+  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-11">
     <p>This test is not readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail|colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-12">
+  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail|colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-12">
     <p>This test is not readable, but on screen it is</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundGradientContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-13">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundGradientContrast:pass" data-accessibility-test="colorFontContrast" id="test-13">
     <p>This test is readable, does not check the gradient since there's a background color.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-14">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindContrast:fail" data-accessibility-test="colorFontContrast" id="test-14">
     <div class="bck"></div>
     <p class="txt">This test is not readable.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-16">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-16">
     <div class="bck"></div>
     <p class="txt">This test is not readable.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundImageContrast:fail" data-accessibility-test="cssTextHasContrast" id="test-18">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundImageContrast:fail" data-accessibility-test="colorFontContrast" id="test-18">
     <div class="bck"></div>
     <p class="txt">This test is not readable.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:cantTell" data-accessibility-test="cssTextHasContrast" id="test-19">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:cantTell" data-accessibility-test="colorFontContrast" id="test-19">
     <p>This test is readable, non existing background</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:pass|colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="cssTextHasContrast" id="test-20">
+  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:pass|colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="colorFontContrast" id="test-20">
     <p>This test is readable, external image</p>
   </div>
 

--- a/test/accessibility-tests/colorFontContrast.html
+++ b/test/accessibility-tests/colorFontContrast.html
@@ -193,54 +193,54 @@
     <p>This test is readable, 16px and font weight 700</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundImageContrast:fail|colorBackgroundImageContrast:fail" data-accessibility-test="colorFontContrast" id="test-7">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-7">
     <p>This test is not readable, thanks to the fish</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:pass|colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="colorFontContrast" id="test-8">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-8">
     <p>This test is readable, thanks to the kids</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-9">
+  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="colorFontContrast" id="test-9">
     <p>This test is not readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:pass" data-accessibility-test="colorFontContrast" id="test-10">
+  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="colorFontContrast" id="test-10">
     <p>This test is readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-11">
+  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="colorFontContrast" id="test-11">
     <p>This test is not readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:fail|colorBackgroundGradientContrast:fail|colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-12">
+  <div class="quail-test" data-expected="colorFontContrast:fail" data-accessibility-test="colorFontContrast" id="test-12">
     <p>This test is not readable, but on screen it is</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundGradientContrast:pass" data-accessibility-test="colorFontContrast" id="test-13">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-13">
     <p>This test is readable, does not check the gradient since there's a background color.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindContrast:fail" data-accessibility-test="colorFontContrast" id="test-14">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-14">
     <div class="bck"></div>
     <p class="txt">This test is not readable.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundGradientContrast:fail" data-accessibility-test="colorFontContrast" id="test-16">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-16">
     <div class="bck"></div>
     <p class="txt">This test is not readable.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorElementBehindBackgroundImageContrast:fail" data-accessibility-test="colorFontContrast" id="test-18">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-18">
     <div class="bck"></div>
     <p class="txt">This test is not readable.</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:cantTell" data-accessibility-test="colorFontContrast" id="test-19">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-19">
     <p>This test is readable, non existing background</p>
   </div>
 
-  <div class="quail-test" data-expected="colorFontContrast:pass|colorBackgroundImageContrast:pass|colorElementBehindBackgroundImageContrast:pass" data-accessibility-test="colorFontContrast" id="test-20">
+  <div class="quail-test" data-expected="colorFontContrast:pass" data-accessibility-test="colorFontContrast" id="test-20">
     <p>This test is readable, external image</p>
   </div>
 


### PR DESCRIPTION
This pulls the six sub tests of color.js out into individual tests.

Two of the tests fails on the command-line test run, but pass in the browser. Given that I'm rewriting the testing harness right now and that an hour of investigation revealed that our use of Qunit.testSuites is very very brittle, I'm inclined to ignore these two failures.

The 2.3.0 release will no longer use Qunit, so let's just push forward to that. For now, that at least let's us run color tests in the 2.2.x release.