### PR TITLE
Unable to read ".jshintrc" file (Error code: ENOENT).

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,19 +30,8 @@ module.exports = function(grunt) {
     },
     concat: {
       options: {
-        banner: [
-          "<%= pkg.options.banner %>",
-          "!function(root, factory) {",
-          "  if (typeof define === 'function' && define.amd) {",
-          "    define(['jquery'], factory);",
-          "  } else {",
-          "    factory(root.jQuery);",
-          "  }",
-          "}(this, function($) {",
-          "  'use strict';",
-          "  var jQuery = $;"
-          ].join("\n"),
-        footer: "\n" + '});',
+        banner: '<%= pkg.options.banner %>' + "\n" + ';(function($) {' + "\n" + '\'use strict\';' + '\n',
+        footer: "\n" + '})(jQuery);',
         stripBanners: true
       },
       dist: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,8 +30,19 @@ module.exports = function(grunt) {
     },
     concat: {
       options: {
-        banner: '<%= pkg.options.banner %>' + "\n" + ';(function($) {' + "\n" + '\'use strict\';' + '\n',
-        footer: "\n" + '})(jQuery);',
+        banner: [
+          "<%= pkg.options.banner %>",
+          "!function(root, factory) {",
+          "  if (typeof define === 'function' && define.amd) {",
+          "    define(['jquery'], factory);",
+          "  } else {",
+          "    factory(root.jQuery);",
+          "  }",
+          "}(this, function($) {",
+          "  'use strict';",
+          "  var jQuery = $;"
+          ].join("\n"),
+        footer: "\n" + '});',
         stripBanners: true
       },
       dist: {

--- a/bower.json
+++ b/bower.json
@@ -3,13 +3,12 @@
   "version": "2.1.0",
   "main": "dist/*",
   "ignore": [
-    ".jshintrc",
     "**/*.txt"
   ],
   "dependencies": {
     "jquery": "~2.0.3",
     "node-htmlparser": "~2.0.0",
-    "RainbowVis-JS" : "https://github.com/anomal/RainbowVis-JS.git"
+    "RainbowVis-JS": "https://github.com/anomal/RainbowVis-JS.git"
   },
   "devDependencies": {
     "qunit": "~1.14.0",


### PR DESCRIPTION
Running the following commands (or using a [subgrunt](https://www.npmjs.com/package/grunt-subgrunt) task) to use quail as part of an existing project...
````
bower install quail
cd bower_components/quail
npm install
grunt build
````
fails with the following:
````
Running "jshint:project_env" (jshint) task
Warning: Unable to read ".jshintrc" file (Error code: ENOENT). Use --force to continue.

Aborted due to warnings.
````

By including the quail project's .jshintrc files, this can be avoided.  (Or I can just keep `--force`ing the build)