### PR TITLE
Allow quail plugin to be used as an AMD Module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,8 @@ module.exports = function(grunt) {
           "    factory(root.jQuery);",
           "  }",
           "}(this, function($) {",
-          "  'use strict';"
+          "  'use strict';",
+          "  var jQuery = jQuery || $;"
           ].join("\n"),
         footer: "\n" + '});',
         stripBanners: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,8 +30,18 @@ module.exports = function(grunt) {
     },
     concat: {
       options: {
-        banner: '<%= pkg.options.banner %>' + "\n" + ';(function($) {' + "\n" + '\'use strict\';' + '\n',
-        footer: "\n" + '})(jQuery);',
+        banner: [
+          "<%= pkg.options.banner %>",
+          "!function(root, factory) {",
+          "  if (typeof define === 'function' && define.amd) {",
+          "    define(['jquery'], factory);",
+          "  } else {",
+          "    factory(root.jQuery);",
+          "  }",
+          "}(this, function($) {",
+          "  'use strict';"
+          ].join("\n"),
+        footer: "\n" + '});',
         stripBanners: true
       },
       dist: {


### PR DESCRIPTION
Allow use as an AMD module, as defined here: https://github.com/umdjs/umd

Also ensures that `jQuery` is defined as well, as it's referenced directly by some components (eg: *src/js/lib/tableHeaders.js*).