### PR TITLE
Improve pNotUsedAsHeader

### DIFF
--- a/src/js/custom/pNotUsedAsHeader.js
+++ b/src/js/custom/pNotUsedAsHeader.js
@@ -1,5 +1,4 @@
 quail.pNotUsedAsHeader = function(quail, test, Case) {
-  var priorStyle = { };
   test.get('$scope').find('p').each(function() {
     var _case = Case({
       element : this,
@@ -13,7 +12,9 @@ quail.pNotUsedAsHeader = function(quail, test, Case) {
     }
     var failed = false;
     if ($(this).text().search('.') < 1) {
-      var $paragraph = $(this);
+      var $paragraph = $(this),
+        priorParagraph = $paragraph.prev('p');
+      // Checking if any of suspectPHeaderTags has exact the same text as a paragraph.
       $.each(quail.suspectPHeaderTags, function(index, tag) {
         if ($paragraph.find(tag).length) {
           $paragraph.find(tag).each(function() {
@@ -26,16 +27,19 @@ quail.pNotUsedAsHeader = function(quail, test, Case) {
           });
         }
       });
-      $.each(quail.suspectPCSSStyles, function(index, style) {
-        if (typeof priorStyle[style] !== 'undefined' &&
-           priorStyle[style] !== $paragraph.css(style)) {
-          _case.set({
-            'status': 'failed'
-          });
-          failed = true;
-        }
-        priorStyle[style] = $paragraph.css(style);
-      });
+
+      // Checking if previous paragraph has a different values for style properties given in quail.suspectPCSSStyles.
+      if ( priorParagraph.length ) {
+        $.each(quail.suspectPCSSStyles, function(index, cssProperty) {
+          if ( $paragraph.css(cssProperty) !== priorParagraph.css(cssProperty) ) {
+            _case.set({
+              'status': 'failed'
+            });
+            failed = true;
+            return false; // Micro optimization - we no longer need to iterate here. jQuery css() method might be expansive.
+          }
+        });
+      }
       if ($paragraph.css('font-weight') === 'bold') {
         _case.set({
           'status': 'failed'

--- a/test/accessibility-tests/pNotUsedAsHeader.html
+++ b/test/accessibility-tests/pNotUsedAsHeader.html
@@ -4,6 +4,14 @@
     <title>pNotUsedAsHeader</title>
 </head>
 <body>
+    <style type="text/css">
+    blockquote.styled
+    {
+        font-style: italic;
+        font-family: Georgia, Times, "Times New Roman", serif;
+    }
+    </style>
+
     <div class="quail-test" data-expected="fail" data-accessibility-test="pNotUsedAsHeader">
         <p class="quail-failed-element"> <b>Looks like a header</b>
         </p>
@@ -53,6 +61,28 @@
     <div class="quail-test" data-expected="pass" data-accessibility-test="pNotUsedAsHeader">
 
         <p>This is a regular paragraph</p>
+    </div>
+
+    <div class="quail-test" data-expected="pass" data-accessibility-test="pNotUsedAsHeader">
+        <p>Foo.</p>
+        <blockquote class="styled">
+            <p>Bar.</p>
+        </blockquote>
+    </div>
+
+    <div class="quail-test" data-expected="pass" data-accessibility-test="pNotUsedAsHeader">
+        <table style="font-size:12.3199996948242px; line-height:1.5em;">
+            <tbody>
+                <tr>
+                    <td>
+                        <p>asd</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <p>
+            <strong>foo</strong> - bar baz bom.
+        </p>
     </div>
 
     <script src="../quail-testrunner.js"></script>


### PR DESCRIPTION
Currently `pNotUsedAsHeader` might give some false positives.

Please see cksource/quail#1 for more details.

Reminder: I don't see 590733055f2f79cf94d958407ce9f14daa2e7e3a commit in `dev` branch so make sure it's merged.