### PR TITLE
Improved the regular expression

### DIFF
--- a/src/js/custom/documentVisualListsAreMarkedUp.js
+++ b/src/js/custom/documentVisualListsAreMarkedUp.js
@@ -1,5 +1,24 @@
 quail.documentVisualListsAreMarkedUp = function(quail, test, Case) {
-  var symbols = /(<br(\/)?>)(\s)(♦|›|»|‣|▶|.|◦|✓|◽|•|—|◾|\||\*|&bull;|&#8226;|[0-9].|\(?[0-9]\)|[\u25A0-\u25FF]|(?:[IXC][MD]|D?C{0,4}))/i;
+
+  var itemStarters = [
+    '♦', '›', '»', '‣', '▶', '◦', '✓', '◽', '•', '—', '◾', // single characters
+    '-\\D',                       // dash, except for negative numbers
+    '\\\\',                       // Just an escaped slash
+    '\\*(?!\\*)',                 // *, but not ** (which could be a foot note)
+    '\\.\\s', 'x\\s',             // characters that should be followed by a space
+    '&bull;', '&#8226;', '&gt;',  // HTML entities
+    '[0-9]+\\.', '\\(?[0-9]+\\)', // Numbers: 1., 13., 13), (14)
+    '[\\u25A0-\\u25FF]',          // Unicode characters that look like bullets
+    '[IVX]{1,5}\\.\\s'            // Roman numerals up to (at least) 27, followed by ". " E.g. II. IV.
+  ];
+
+  var symbols = RegExp(
+    '(^|<br[^>]*>)' +                   // Match the String start or a <br> element
+    '[\\s]*' +                          // Optionally followed by white space characters
+    '(' + itemStarters.join('|') + ')', // Followed by a character that could indicate a list
+  'gi'); // global (for counting), case insensitive (capitalisation in elements / entities)
+
+
   test.get('$scope').find(quail.textSelector).each(function() {
     var _case = Case({
       element: this,

--- a/test/accessibility-tests/documentVisualListsAreMarkedUp.html
+++ b/test/accessibility-tests/documentVisualListsAreMarkedUp.html
@@ -18,6 +18,13 @@
 			<br/>
 		</p>
 	</div>
+
+	<div class="quail-test" data-expected="fail" data-accessibility-test="documentVisualListsAreMarkedUp">
+		<p class="quail-failed-element">
+			-chocolate<br class="somestuff">-vanilla<br>-cherry<br data-attribute>-bananna
+		</p>
+	</div>
+
 	<div class="quail-test" data-expected="fail" data-accessibility-test="documentVisualListsAreMarkedUp">
 
 		<p class="quail-failed-element">
@@ -82,11 +89,26 @@
 			♦ bananna
 			<br/>
 		</p>
-	</div>	
+	</div>
 	<div class="quail-test" data-expected="pass" data-accessibility-test="documentVisualListsAreMarkedUp">
 
 		<p>
 			Our ice-cream flavours include chocolate*, vanilla*, cherry, and bananna.
+		</p>
+	</div>
+
+	<div class="quail-test" data-expected="pass" data-accessibility-test="documentVisualListsAreMarkedUp">
+		<p class="quail-failed-element">
+			* Too short <br />
+			* May not be a list
+		</p>
+	</div>
+
+	<div class="quail-test" data-expected="pass" data-accessibility-test="documentVisualListsAreMarkedUp">
+		<p class="quail-failed-element">
+			* Footnotes, <br />
+			** are not lists, <br />
+			*** so they should pass.
 		</p>
 	</div>
 


### PR DESCRIPTION
Found a problem when working with CKEditor. Turns out quite a few things went wrong in this test:
- It didn't match the string start, just &lt;br&gt;
- It didn't allow for &lt;br&gt; with attributes
- It assumed space characters between br and the item symbol
- Roman numberals were incorrect
- Didn't match the dash character
- The counting of items didn't work because the 'g' flag was not used on the regexp
- Only allowed for single digit numbers

These should all be fixed now.