### PR TITLE
Fixed #5 - Fixed a typo in `imgAltIsTooLong` assessment.

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -2389,7 +2389,7 @@ imgAltIsTooLong:
   type: "custom"
   testability: 1
   title:
-    en: "Image Alt text is short"
+    en: "Image Alt text is too long"
     nl: "Altteksten voor een afbeelding zijn kort"
   description:
     en: "All \"alt\" attributes for <code>img</code> elements should be clear and concise. \"Alt\" attributes over 100 characters long should be reviewed to see if they are too long."


### PR DESCRIPTION
There's still a typo in `imgAltIsTooLong`.

We need to have changes in this [fix commit](https://github.com/cksource/quail/commit/9d502e90303c2f9b63c4b05659bd565880fbfc4c) also in **2.2.x**.