### PR TITLE
Img alt goes unchecked if image is hidden

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -2508,8 +2508,7 @@ imgHasAlt:
     - "image"
     - "content"
   options:
-    selector: "img:visible"
-    test: ":not(img[alt])"
+    selector: "img:not(img[alt])"
 imgHasLongDesc:
   type: "custom"
   testability: 1

--- a/test/accessibility-tests/imgHasAlt.html
+++ b/test/accessibility-tests/imgHasAlt.html
@@ -4,13 +4,7 @@
 		<title>imgHasAlt</title>
 	</head>
 	<body>
-
-		<div class="quail-test" data-expected="inapplicable"
-		data-accessibility-test="imgHasAlt">
-			<!-- no content -->
-		</div>
-
-		<div class="quail-test" data-expected="inapplicable"
+		<div class="quail-test" data-expected="pass"
 		data-accessibility-test="imgHasAlt">
 		  <img src="../assets/rex.jpg" style="display:none" alt="My cat"/>
 		</div>
@@ -23,6 +17,11 @@
 		  <img src="../assets/rex.jpg" class="quail-failed-element" />
 		</div>
 
+		<div class="quail-test" data-expected="fail" data-accessibility-test="imgHasAlt">
+			<div style="display: none">
+				<img src="../assets/rex.jpg" class="quail-failed-element" />
+			</div>
+		</div>
 
 		<script src="../quail-testrunner.js"></script>	</body>
 </html>


### PR DESCRIPTION
Subject assessment: [`imgHasAlt`](https://github.com/quailjs/quail/blob/e09251ef5be9cc7b6c4320f497ddbb7b7287af19/src/resources/tests.yml#L2490-2512).

If the image is hidden (e.g. `display:none` parent) then it won't be checked.

We should check all the images despite them being visible or not. A common case might be that keeps some content parts in hiddien container - like slider, tabbed content.

E.g. simplified tabbed content (without any classes/aria markup) might be created like so:

```html
<!-- All the section[data-tab-content] are display:none by default. -->
<nav>
	<ol>
		<li><a data-content-id="foo">tab1</a></li>
		<li><a data-content-id="bar">tab2</a></li>
		<li><a data-content-id="baz">tab3</a></li>
	</ol>
</nav>

<section data-tab-content="foo">
	<!--Some markup.-->
</section>

<section data-tab-content="bar">
	<img src="...">
	<!--Some markup.-->
</section>
```

So images in tabs would pass unchecked, while it's important part of the content.

On top of it using jQuery `:visible` filter greatly affects the performance.

Visibility check was introduced in [this commit](https://github.com/quailjs/quail/commit/cc7394443690ac0e77941a00229269af633e8e08). We'll cover only `img` here, as it's a priority, but other cases should be checked as well.

Source issue: cksource/quail#6.