### PR TITLE
imgAltNotEmptyInAnchor improvements

### DIFF
--- a/src/js/custom/imgAltNotEmptyInAnchor.js
+++ b/src/js/custom/imgAltNotEmptyInAnchor.js
@@ -1,20 +1,21 @@
 quail.imgAltNotEmptyInAnchor = function(quail, test, Case) {
   test.get('$scope').find('a[href] img').each(function() {
     var $img  = $(this);
+    var $a   = $img.closest('a');
+    var text = $a.text();
+
     var _case = Case({
       element: this,
       expected: $img.closest('.quail-test').data('expected')
     });
     test.add(_case);
 
-    var $a   = $img.closest('a');
-    var text = $a.text();
-    $a.find('img[alt]').not(this).each(function () {
+    // Concat all alt attributes of images to the text of the paragraph
+    $a.find('img[alt]').each(function () {
       text += ' ' + $(this).attr('alt');
     });
 
-    if (quail.isUnreadable($(this).attr('alt')) &&
-        quail.isUnreadable(text)) {
+    if (quail.isUnreadable(text)) {
       _case.set({
         'status': 'failed'
       });

--- a/src/js/custom/imgAltNotEmptyInAnchor.js
+++ b/src/js/custom/imgAltNotEmptyInAnchor.js
@@ -1,12 +1,11 @@
 quail.imgAltNotEmptyInAnchor = function(quail, test, Case) {
-  test.get('$scope').find('a[href] img').each(function() {
-    var $img  = $(this);
-    var $a   = $img.closest('a');
+  test.get('$scope').find('a[href]:has(img)').each(function() {
+    var $a   = $(this);
     var text = $a.text();
 
     var _case = Case({
-      element: $a[0],
-      expected: $img.closest('.quail-test').data('expected')
+      element: this,
+      expected: $a.closest('.quail-test').data('expected')
     });
     test.add(_case);
 

--- a/src/js/custom/imgAltNotEmptyInAnchor.js
+++ b/src/js/custom/imgAltNotEmptyInAnchor.js
@@ -1,12 +1,20 @@
 quail.imgAltNotEmptyInAnchor = function(quail, test, Case) {
-  test.get('$scope').find('a img').each(function() {
+  test.get('$scope').find('a[href] img').each(function() {
+    var $img  = $(this);
     var _case = Case({
       element: this,
-      expected: $(this).closest('.quail-test').data('expected')
+      expected: $img.closest('.quail-test').data('expected')
     });
     test.add(_case);
+
+    var $a   = $img.closest('a');
+    var text = $a.text();
+    $a.find('img[alt]').not(this).each(function () {
+      text += ' ' + $(this).attr('alt');
+    });
+
     if (quail.isUnreadable($(this).attr('alt')) &&
-        quail.isUnreadable($(this).parent('a:first').text())) {
+        quail.isUnreadable(text)) {
       _case.set({
         'status': 'failed'
       });

--- a/src/js/custom/imgAltNotEmptyInAnchor.js
+++ b/src/js/custom/imgAltNotEmptyInAnchor.js
@@ -5,7 +5,7 @@ quail.imgAltNotEmptyInAnchor = function(quail, test, Case) {
     var text = $a.text();
 
     var _case = Case({
-      element: this,
+      element: $a[0],
       expected: $img.closest('.quail-test').data('expected')
     });
     test.add(_case);

--- a/test/accessibility-tests/imgAltNotEmptyInAnchor.html
+++ b/test/accessibility-tests/imgAltNotEmptyInAnchor.html
@@ -1,25 +1,52 @@
 <!doctype html>
 <html>
 <head>
-	<title>imgAltNotEmptyInAnchor</title>
+  <title>imgAltNotEmptyInAnchor</title>
 </head>
 <body>
-	<div class="quail-test" data-expected="fail" data-accessibility-test="imgAltNotEmptyInAnchor">
-		<p>
-			<a href="rex.html">
-				<img src="../assets/rex.jpg" alt="" class="quail-failed-element"/>
-			</a>
-		</p>
-	</div>
+  <div class="quail-test" data-expected="fail" data-accessibility-test="imgAltNotEmptyInAnchor">
+    <p>
+      <a href="rex.html">
+        <img src="../assets/rex.jpg" alt="" class="quail-failed-element"/>
+      </a>
+    </p>
+  </div>
 
-	<div class="quail-test" data-expected="pass" data-accessibility-test="imgAltNotEmptyInAnchor">
-		<p>
-			<a href="rex.html">
-				<img src="../assets/rex.jpg" alt="a story about Rex the cat"/>
-			</a>
-		</p>
-	</div>
 
-	<script src="../quail-testrunner.js"></script>
+  <div class="quail-test" data-expected="fail" data-accessibility-test="imgAltNotEmptyInAnchor">
+    <p>
+      <a href="rex.html">
+        <b><img src="../assets/rex.jpg" alt="" class="quail-failed-element"/></b>
+      </a>
+    </p>
+  </div>
+
+  <div class="quail-test" data-expected="pass" data-accessibility-test="imgAltNotEmptyInAnchor">
+    <p>
+      <a href="rex.html">
+        <img src="../assets/rex.jpg" alt="a story about Rex the cat"/>
+      </a>
+    </p>
+  </div>
+
+  <div class="quail-test" data-expected="pass" data-accessibility-test="imgAltNotEmptyInAnchor">
+    <p>
+      <a href="rex.html">
+        <img src="../assets/rex.jpg" alt=""/> <b>a story about Rex the cat</b>
+      </a>
+    </p>
+  </div>
+
+  <div class="quail-test" data-expected="pass" data-accessibility-test="imgAltNotEmptyInAnchor">
+    <p>
+      <a href="rex.html">
+        <img src="../assets/rex.jpg" alt="a story about Rex the cat"/>
+        <img src="../assets/rex.jpg" alt=""/>
+        <img src="../assets/rex.jpg" alt=""/>
+      </a>
+    </p>
+  </div>
+
+  <script src="../quail-testrunner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Allow multiple img elements in an anchor and return the anchor element instead of the img.