### PR TITLE
Refactor and patch color tests

### DIFF
--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -3,8 +3,6 @@
  * color contrast/luminosity.
  */
 quail.components.color = (function () {
-  var img, i, rainbow, numberOfSamples;
-
 
   function buildCase(test, Case, element, status, id, message) {
     test.add(Case({
@@ -465,220 +463,7 @@ quail.components.color = (function () {
     }
   };
 
-  var tests = {
-    /**
-     *
-     */
-    colorFontContrast: function (options, test, Case, element, id, $this) {
-      // Check text and background color using DOM.
-      // Build a case.
-
-      if (!colors.testElmContrast(options.algorithm, $this)) {
-        buildCase(test, Case, element, 'failed', id, 'The font contrast of the text impairs readability');
-      }
-      else {
-        buildCase(test, Case, element, 'passed', id, 'The font contrast of the text is sufficient for readability');
-      }
-    },
-
-    /**
-     *
-     */
-    colorElementBehindContrast: function (id, test, Case, options, $this, element) {
-      // Check text and background using element behind current element.
-      var backgroundColorBehind;
-      // The option element is problematic.
-      if (!$this.is('option')) {
-        backgroundColorBehind = colors.getBehindElementBackgroundColor($this);
-      }
-      if (!backgroundColorBehind) {
-        return;
-      }
-
-      var testResult = colors.testElmBackground(options.algorithm, $this,
-            backgroundColorBehind);
-
-      // Build a case.
-      if (!testResult) {
-        buildCase(test, Case, element, 'failed', id, 'The element behind this element makes the text unreadable');
-      }
-      else {
-        buildCase(test, Case, element, 'passed', id, 'The element behind this element does not affect readability');
-      }
-
-    },
-
-    /**
-     *
-     */
-    colorBackgroundImageContrast: function (id, test, Case, options, $this, element) {
-      // Check if there's a backgroundImage using DOM.
-      var backgroundImage = colors.getBackgroundImage($this);
-      if (!backgroundImage) {
-        return;
-      }
-
-      img = document.createElement('img');
-      img.crossOrigin = "Anonymous";
-
-      // Get average color of the background image. The image must first load
-      // before information about it is available to the DOM.
-      img.onload = function () {
-        var averageColorBackgroundImage = colors.getAverageRGB(img);
-        var testResult = colors.testElmBackground(options.algorithm, $this,
-              averageColorBackgroundImage);
-
-        // Build a case.
-        if (!testResult) {
-          buildCase(test, Case, element, 'failed', id, 'The element\'s background image makes the text unreadable');
-
-        } else {
-          buildCase(test, Case, element, 'passed', id, 'The element\'s background image does not affect readability');
-        }
-      };
-
-      img.onerror = img.onabort = function () {
-        buildCase(test, Case, element, 'cantTell', id, 'The element\'s background image could not be loaded (' + backgroundImage + ')');
-      };
-
-      // Load the image.
-      img.src = backgroundImage;
-    },
-
-    /**
-     *
-     */
-    colorElementBehindBackgroundImageContrast: function (id, test, Case, options, $this, element) {
-      // Check if there's a backgroundImage using element behind current element.
-      var behindBackgroundImage;
-
-      // The option element is problematic.
-      if (!$this.is('option')) {
-        behindBackgroundImage = colors.getBehindElementBackgroundImage($this);
-      }
-
-      if (!behindBackgroundImage) {
-        return;
-      }
-
-      img = document.createElement('img');
-      img.crossOrigin = "Anonymous";
-      // The image must first load before information about it is available to
-      // the DOM.
-      img.onload = function () {
-
-        // Get average color of the background image.
-        var averageColorBehindBackgroundImage = colors.getAverageRGB(img);
-        var testResult = colors.testElmBackground(options.algorithm, $this,
-              averageColorBehindBackgroundImage);
-        if (!testResult) {
-          buildCase(test, Case, element, 'failed', id, 'The background image of the element behind this element makes the text unreadable');
-
-        } else {
-          buildCase(test, Case, element, 'passed', id, 'The background image of the element behind this element does not affect readability');
-        }
-      };
-      img.onerror = img.onabort = function () {
-        buildCase(test, Case, element, 'cantTell', id, 'The background image of the element behind this element could not be loaded (' + behindBackgroundImage + ')');
-      };
-      // Load the image.
-      img.src = behindBackgroundImage;
-
-    },
-
-    /**
-     *
-     */
-    colorBackgroundGradientContrast: function (id, test, Case, options, $this, element) {
-      // Check if there's a background gradient using DOM.
-      var failureFound;
-      var backgroundGradientColors = colors.getBackgroundGradient($this);
-
-      if (!backgroundGradientColors) {
-        return;
-      }
-
-      // Convert colors to hex notation.
-      for (i = 0; i < backgroundGradientColors.length; i++) {
-        if (backgroundGradientColors[i].substr(0, 3) === 'rgb') {
-          backgroundGradientColors[i] = colors.colorToHex(backgroundGradientColors[i]);
-        }
-      }
-
-      // Create a rainbow.
-      /* global Rainbow */
-      rainbow = new Rainbow();
-      rainbow.setSpectrumByArray(backgroundGradientColors);
-      // @todo, make the number of samples configurable.
-      numberOfSamples = backgroundGradientColors.length * options.gradientSampleMultiplier;
-
-      // Check each color.
-      failureFound = false;
-      for (i = 0; !failureFound && i < numberOfSamples; i++) {
-        var testResult = colors.testElmBackground(options.algorithm, $this,
-              '#' + rainbow.colourAt(i));
-
-        if (!testResult) {
-          buildCase(test, Case, element, 'failed', id, 'The background gradient makes the text unreadable');
-          failureFound = true;
-        }
-      }
-
-      // If no failure was found, the element passes for this case type.
-      if (!failureFound) {
-        buildCase(test, Case, element, 'passed', id, 'The background gradient does not affect readability');
-      }
-    },
-
-    /**
-     *
-     */
-    colorElementBehindBackgroundGradientContrast: function (id, test, Case, options, $this, element) {
-      // Check if there's a background gradient using element behind current element.
-      var behindGradientColors;
-      var failureFound;
-      // The option element is problematic.
-      if (!$this.is('option')) {
-        behindGradientColors = colors.getBehindElementBackgroundGradient($this);
-      }
-
-      if (!behindGradientColors) {
-        return;
-      }
-
-      // Convert colors to hex notation.
-      for (i = 0; i < behindGradientColors.length; i++) {
-        if (behindGradientColors[i].substr(0, 3) === 'rgb') {
-          behindGradientColors[i] = colors.colorToHex(behindGradientColors[i]);
-        }
-      }
-
-      // Create a rainbow.
-      /* global Rainbow */
-      rainbow = new Rainbow();
-      rainbow.setSpectrumByArray(behindGradientColors);
-      numberOfSamples = behindGradientColors.length * options.gradientSampleMultiplier;
-
-      // Check each color.
-      failureFound = false;
-      for (i = 0; !failureFound && i < numberOfSamples; i++) {
-        failureFound = !colors.testElmBackground(options.algorithm, $this,
-              '#' + rainbow.colourAt(i));
-      }
-
-      // If no failure was found, the element passes for this case type.
-      if (failureFound) {
-        buildCase(test, Case, element, 'failed', id, 'The background gradient of the element behind this element makes the text unreadable');
-      } else {
-        buildCase(test, Case, element, 'passed', id, 'The background gradient of the element behind this element does not affect readability');
-      }
-    }
-  };
-
-  /**
-   *
-   */
-  function testCandidates(id, textNode, test, Case, options) {
+  function textShouldBeTested(textNode) {
     // We want a tag, not just the text node.
     var element = textNode.parentNode;
     var $this = $(element);
@@ -688,32 +473,23 @@ quail.components.color = (function () {
     // Failure to pass an Element <node> to window.getComputedStyle will raised an exception
     // if Firefox.
     if (element.nodeType !== 1) {
-      return;
-    }
+      return false;
+
     // Ignore elements whose content isn't displayed to the page.
-    if (['script', 'style', 'title', 'object', 'applet', 'embed', 'template', 'noscript']
+    } else if (['script', 'style', 'title', 'object', 'applet', 'embed', 'template', 'noscript']
     .indexOf(element.nodeName.toLowerCase()) !== -1)  {
-      return;
-    }
+      return false;
 
     // Bail out if the text is not readable.
-    if (quail.isUnreadable($this.text())) {
-      buildCase(test, Case, element, 'cantTell', '', 'The text cannot be processed');
-      return;
-    }
+    } else if (quail.isUnreadable($this.text())) {
+      return false;
 
-    // Switch on the type of color test to run.
-    if (tests[id]) {
-      try {
-        tests[id](id, test, Case, options, $this, element);
-      } catch (e) {
-        console.log(e);
-      }
+    } else {
+      return true;
     }
   }
 
-
-    /**
+  /**
    * For the color test, if any case passes for a given element, then all the
    * cases for that element pass.
    */
@@ -754,7 +530,7 @@ quail.components.color = (function () {
 
   return {
     colors: colors,
-    testCandidates: testCandidates,
+    textShouldBeTested: textShouldBeTested,
     postInvoke: postInvoke,
     buildCase: buildCase
   };

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -15,6 +15,12 @@ quail.components.color = (function () {
     }));
   }
 
+  function notempty(s) {
+    return $.trim(s) !== '';
+  }
+
+
+
   var colors = {
     cache: {},
     /**
@@ -23,8 +29,8 @@ quail.components.color = (function () {
      */
     getLuminosity : function(foreground, background) {
       var cacheKey = 'getLuminosity_' + foreground + '_' + background;
-      foreground = colors.cleanup(foreground);
-      background = colors.cleanup(background);
+      foreground = colors.parseColor(foreground);
+      background = colors.parseColor(background);
 
       if (colors.cache[cacheKey] !== undefined) {
         return colors.cache[cacheKey];
@@ -81,14 +87,6 @@ quail.components.color = (function () {
       return res;
     },
 
-    testColorContrast: function (algorithm, element, foreground, background, level) {
-      if (algorithm === 'wcag') {
-        return colors.passesWCAGColor(element, foreground, background, level);
-      } else if (algorithm === 'wai') {
-        return colors.passesWAIColor(foreground, background);
-      }
-    },
-
     /**
      * Returns whether an element's color passes
      * WCAG at a certain contrast ratio.
@@ -117,8 +115,10 @@ quail.components.color = (function () {
      * WAI brightness levels.
      */
     passesWAIColor : function(foreground, background) {
-      return (colors.getWAIErtContrast(foreground, background) > 500 &&
-              colors.getWAIErtBrightness(foreground, background) > 125);
+      var contrast   = colors.getWAIErtContrast(foreground, background);
+      var brightness = colors.getWAIErtBrightness(foreground, background);
+
+      return (contrast > 500 && brightness > 125);
     },
 
     /**
@@ -195,7 +195,7 @@ quail.components.color = (function () {
     /**
      * Returns an object with rgba taken from a string.
      */
-    cleanup : function(color) {
+    parseColor : function(color) {
       if (typeof color === 'object') {
         return color;
       }
@@ -361,10 +361,6 @@ quail.components.color = (function () {
       if (colors.cache[cacheKey] !== undefined) {
         return colors.cache[cacheKey];
       }
-
-      var notempty = function(s) {
-        return $.trim(s) !== '';
-      };
 
       var foundIt;
       var scannedElements = [];

--- a/src/js/custom/colorBackgroundGradientContrast.js
+++ b/src/js/custom/colorBackgroundGradientContrast.js
@@ -1,21 +1,75 @@
 quail.colorBackgroundGradientContrast = function (quail, test, Case, options) {
-  test.get('$scope').each(function () {
-    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
-    var nodes = [];
-    var text = textnodes.iterateNext();
-    if (!text) {
-      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+
+  var colors    = quail.components.color.colors;
+  var buildCase =  quail.components.color.buildCase;
+  var id        = 'colorBackgroundGradientContrast';
+
+  /**
+   *
+   */
+  function colorBackgroundGradientContrast(test, Case, options, $this, element) {
+    // Check if there's a background gradient using DOM.
+    var failureFound, rainbow, numberOfSamples;
+    var backgroundGradientColors = colors.getBackgroundGradient($this);
+
+    if (!backgroundGradientColors) {
+      return;
     }
-    else {
-      // Loop has to be separated. If we try to iterate and rund testCandidates
-      // the xpath thing will crash because document is being modified.
-      while (text) {
-        nodes.push(text);
-        text = textnodes.iterateNext();
+
+    // Convert colors to hex notation.
+    for (var i = 0; i < backgroundGradientColors.length; i++) {
+      if (backgroundGradientColors[i].substr(0, 3) === 'rgb') {
+        backgroundGradientColors[i] = colors.colorToHex(backgroundGradientColors[i]);
       }
-      nodes.forEach(function (textNode) {
-        quail.components.color.testCandidates('colorBackgroundGradientContrast', textNode, test, Case, options);
-      });
     }
+
+    // Create a rainbow.
+    /* global Rainbow */
+    rainbow = new Rainbow();
+    rainbow.setSpectrumByArray(backgroundGradientColors);
+    // @todo, make the number of samples configurable.
+    numberOfSamples = backgroundGradientColors.length * options.gradientSampleMultiplier;
+
+    // Check each color.
+    failureFound = false;
+    for (i = 0; !failureFound && i < numberOfSamples; i++) {
+      var testResult = colors.testElmBackground(options.algorithm, $this,
+            '#' + rainbow.colourAt(i));
+
+      if (!testResult) {
+        buildCase(test, Case, element, 'failed', id, 'The background gradient makes the text unreadable');
+        failureFound = true;
+      }
+    }
+
+    // If no failure was found, the element passes for this case type.
+    if (!failureFound) {
+      buildCase(test, Case, element, 'passed', id, 'The background gradient does not affect readability');
+    }
+  }
+
+
+  test.get('$scope').each(function () {
+    var textNodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes     = [];
+    var textNode  = textNodes.iterateNext();
+
+    // Loop has to be separated. If we try to iterate and rund testCandidates
+    // the xpath thing will crash because document is being modified.
+    while (textNode) {
+      if (quail.components.color.textShouldBeTested(textNode)) {
+        nodes.push(textNode.parentNode);
+      }
+      textNode = textNodes.iterateNext();
+    }
+
+    if (nodes.length === 0) {
+      buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+
+    nodes.forEach(function (element) {
+      colorBackgroundGradientContrast(test, Case, options, $(element), element);
+    });
+
   });
 };

--- a/src/js/custom/colorBackgroundImageContrast.js
+++ b/src/js/custom/colorBackgroundImageContrast.js
@@ -1,21 +1,67 @@
 quail.colorBackgroundImageContrast = function (quail, test, Case, options) {
-  test.get('$scope').each(function () {
-    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
-    var nodes = [];
-    var text = textnodes.iterateNext();
-    if (!text) {
-      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+
+  var colors    = quail.components.color.colors;
+  var buildCase =  quail.components.color.buildCase;
+  var id        = 'colorBackgroundImageContrast';
+
+  /**
+   *
+   */
+  function colorBackgroundImageContrast(test, Case, options, $this, element) {
+    // Check if there's a backgroundImage using DOM.
+    var backgroundImage = colors.getBackgroundImage($this);
+    if (!backgroundImage) {
+      return;
     }
-    else {
-      // Loop has to be separated. If we try to iterate and rund testCandidates
-      // the xpath thing will crash because document is being modified.
-      while (text) {
-        nodes.push(text);
-        text = textnodes.iterateNext();
+
+    var img = document.createElement('img');
+    img.crossOrigin = "Anonymous";
+
+    // Get average color of the background image. The image must first load
+    // before information about it is available to the DOM.
+    img.onload = function () {
+      var averageColorBackgroundImage = colors.getAverageRGB(img);
+      var testResult = colors.testElmBackground(options.algorithm, $this,
+            averageColorBackgroundImage);
+
+      // Build a case.
+      if (!testResult) {
+        buildCase(test, Case, element, 'failed', id, 'The element\'s background image makes the text unreadable');
+
+      } else {
+        buildCase(test, Case, element, 'passed', id, 'The element\'s background image does not affect readability');
       }
-      nodes.forEach(function (textNode) {
-        quail.components.color.testCandidates('colorBackgroundImageContrast', textNode, test, Case, options);
-      });
+    };
+
+    img.onerror = img.onabort = function () {
+      buildCase(test, Case, element, 'cantTell', id, 'The element\'s background image could not be loaded (' + backgroundImage + ')');
+    };
+
+    // Load the image.
+    img.src = backgroundImage;
+  }
+
+
+  test.get('$scope').each(function () {
+    var textNodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var textNode = textNodes.iterateNext();
+
+    // Loop has to be separated. If we try to iterate and rund testCandidates
+    // the xpath thing will crash because document is being modified.
+    while (textNode) {
+      if (quail.components.color.textShouldBeTested(textNode)) {
+        nodes.push(textNode.parentNode);
+      }
+      textNode = textNodes.iterateNext();
     }
+
+    if (nodes.length === 0) {
+      buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+
+    nodes.forEach(function (element) {
+      colorBackgroundImageContrast(test, Case, options, $(element), element);
+    });
   });
 };

--- a/src/js/custom/colorElementBehindBackgroundGradientContrast.js
+++ b/src/js/custom/colorElementBehindBackgroundGradientContrast.js
@@ -1,21 +1,76 @@
 quail.colorElementBehindBackgroundGradientContrast = function (quail, test, Case, options) {
-  test.get('$scope').each(function () {
-    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
-    var nodes = [];
-    var text = textnodes.iterateNext();
-    if (!text) {
-      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+
+  var colors    = quail.components.color.colors;
+  var buildCase =  quail.components.color.buildCase;
+  var id        = 'colorElementBehindBackgroundGradientContrast';
+
+
+  /**
+   *
+   */
+  function colorElementBehindBackgroundGradientContrast(test, Case, options, $this, element) {
+    // Check if there's a background gradient using element behind current element.
+    var behindGradientColors;
+    var failureFound;
+    // The option element is problematic.
+    if (!$this.is('option')) {
+      behindGradientColors = colors.getBehindElementBackgroundGradient($this);
     }
-    else {
-      // Loop has to be separated. If we try to iterate and rund testCandidates
-      // the xpath thing will crash because document is being modified.
-      while (text) {
-        nodes.push(text);
-        text = textnodes.iterateNext();
+
+    if (!behindGradientColors) {
+      return;
+    }
+
+    // Convert colors to hex notation.
+    for (var i = 0; i < behindGradientColors.length; i++) {
+      if (behindGradientColors[i].substr(0, 3) === 'rgb') {
+        behindGradientColors[i] = colors.colorToHex(behindGradientColors[i]);
       }
-      nodes.forEach(function (textNode) {
-        quail.components.color.testCandidates('colorElementBehindBackgroundGradientContrast', textNode, test, Case, options);
-      });
     }
+
+    // Create a rainbow.
+    /* global Rainbow */
+    var rainbow = new Rainbow();
+    rainbow.setSpectrumByArray(behindGradientColors);
+    var numberOfSamples = behindGradientColors.length * options.gradientSampleMultiplier;
+
+    // Check each color.
+    failureFound = false;
+    for (i = 0; !failureFound && i < numberOfSamples; i++) {
+      failureFound = !colors.testElmBackground(options.algorithm, $this,
+            '#' + rainbow.colourAt(i));
+    }
+
+    // If no failure was found, the element passes for this case type.
+    if (failureFound) {
+      buildCase(test, Case, element, 'failed', id, 'The background gradient of the element behind this element makes the text unreadable');
+    } else {
+      buildCase(test, Case, element, 'passed', id, 'The background gradient of the element behind this element does not affect readability');
+    }
+  }
+
+
+  test.get('$scope').each(function () {
+    var textNodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var textNode = textNodes.iterateNext();
+
+    // Loop has to be separated. If we try to iterate and rund testCandidates
+    // the xpath thing will crash because document is being modified.
+    while (textNode) {
+      if (quail.components.color.textShouldBeTested(textNode)) {
+        nodes.push(textNode.parentNode);
+      }
+      textNode = textNodes.iterateNext();
+    }
+
+    if (nodes.length === 0) {
+      buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+
+    nodes.forEach(function (element) {
+      colorElementBehindBackgroundGradientContrast(test, Case, options, $(element), element);
+    });
   });
+
 };

--- a/src/js/custom/colorElementBehindBackgroundImageContrast.js
+++ b/src/js/custom/colorElementBehindBackgroundImageContrast.js
@@ -1,21 +1,70 @@
 quail.colorElementBehindBackgroundImageContrast = function (quail, test, Case, options) {
-  test.get('$scope').each(function () {
-    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
-    var nodes = [];
-    var text = textnodes.iterateNext();
-    if (!text) {
-      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+
+  var colors    = quail.components.color.colors;
+  var buildCase =  quail.components.color.buildCase;
+  var id        = 'colorElementBehindBackgroundImageContrast';
+
+  /**
+   *
+   */
+  function colorElementBehindBackgroundImageContrast(test, Case, options, $this, element) {
+    // Check if there's a backgroundImage using element behind current element.
+    var behindBackgroundImage;
+
+    // The option element is problematic.
+    if (!$this.is('option')) {
+      behindBackgroundImage = colors.getBehindElementBackgroundImage($this);
     }
-    else {
-      // Loop has to be separated. If we try to iterate and rund testCandidates
-      // the xpath thing will crash because document is being modified.
-      while (text) {
-        nodes.push(text);
-        text = textnodes.iterateNext();
+
+    if (!behindBackgroundImage) {
+      return;
+    }
+
+    var img = document.createElement('img');
+    img.crossOrigin = "Anonymous";
+    // The image must first load before information about it is available to
+    // the DOM.
+    img.onload = function () {
+
+      // Get average color of the background image.
+      var averageColorBehindBackgroundImage = colors.getAverageRGB(img);
+      var testResult = colors.testElmBackground(options.algorithm, $this,
+            averageColorBehindBackgroundImage);
+      if (!testResult) {
+        buildCase(test, Case, element, 'failed', id, 'The background image of the element behind this element makes the text unreadable');
+
+      } else {
+        buildCase(test, Case, element, 'passed', id, 'The background image of the element behind this element does not affect readability');
       }
-      nodes.forEach(function (textNode) {
-        quail.components.color.testCandidates('colorElementBehindBackgroundImageContrast', textNode, test, Case, options);
-      });
+    };
+    img.onerror = img.onabort = function () {
+      buildCase(test, Case, element, 'cantTell', id, 'The background image of the element behind this element could not be loaded (' + behindBackgroundImage + ')');
+    };
+    // Load the image.
+    img.src = behindBackgroundImage;
+  }
+
+
+  test.get('$scope').each(function () {
+    var textNodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var textNode = textNodes.iterateNext();
+
+    // Loop has to be separated. If we try to iterate and rund testCandidates
+    // the xpath thing will crash because document is being modified.
+    while (textNode) {
+      if (quail.components.color.textShouldBeTested(textNode)) {
+        nodes.push(textNode.parentNode);
+      }
+      textNode = textNodes.iterateNext();
     }
+
+    if (nodes.length === 0) {
+      buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+
+    nodes.forEach(function (element) {
+      colorElementBehindBackgroundImageContrast(test, Case, options, $(element), element);
+    });
   });
 };

--- a/src/js/custom/colorElementBehindContrast.js
+++ b/src/js/custom/colorElementBehindContrast.js
@@ -1,21 +1,54 @@
 quail.colorElementBehindContrast = function (quail, test, Case, options) {
-  test.get('$scope').each(function () {
-    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
-    var nodes = [];
-    var text = textnodes.iterateNext();
-    if (!text) {
-      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+
+  var colors    = quail.components.color.colors;
+  var buildCase =  quail.components.color.buildCase;
+  var id        = 'colorElementBehindContrast';
+
+  function colorElementBehindContrast(test, Case, options, $this, element) {
+    // Check text and background using element behind current element.
+    var backgroundColorBehind;
+    // The option element is problematic.
+    if (!$this.is('option')) {
+      backgroundColorBehind = colors.getBehindElementBackgroundColor($this);
+    }
+    if (!backgroundColorBehind) {
+      return;
+    }
+
+    var testResult = colors.testElmBackground(options.algorithm, $this,
+          backgroundColorBehind);
+
+    // Build a case.
+    if (!testResult) {
+      buildCase(test, Case, element, 'failed', id, 'The element behind this element makes the text unreadable');
     }
     else {
-      // Loop has to be separated. If we try to iterate and rund testCandidates
-      // the xpath thing will crash because document is being modified.
-      while (text) {
-        nodes.push(text);
-        text = textnodes.iterateNext();
-      }
-      nodes.forEach(function (textNode) {
-        quail.components.color.testCandidates('colorElementBehindContrast', textNode, test, Case, options);
-      });
+      buildCase(test, Case, element, 'passed', id, 'The element behind this element does not affect readability');
     }
+  }
+
+
+  test.get('$scope').each(function () {
+    var textNodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var textNode = textNodes.iterateNext();
+
+    // Loop has to be separated. If we try to iterate and rund testCandidates
+    // the xpath thing will crash because document is being modified.
+    while (textNode) {
+      if (quail.components.color.textShouldBeTested(textNode)) {
+        nodes.push(textNode.parentNode);
+      }
+      textNode = textNodes.iterateNext();
+    }
+
+    if (nodes.length === 0) {
+      buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+
+    nodes.forEach(function (element) {
+      colorElementBehindContrast(test, Case, options, $(element), element);
+    });
+
   });
 };

--- a/src/js/custom/colorFontContrast.js
+++ b/src/js/custom/colorFontContrast.js
@@ -1,21 +1,44 @@
 quail.colorFontContrast = function (quail, test, Case, options) {
-  test.get('$scope').each(function () {
-    var textnodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
-    var nodes = [];
-    var text = textnodes.iterateNext();
-    if (!text) {
-      quail.components.color.buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+
+  var colors    = quail.components.color.colors;
+  var buildCase =  quail.components.color.buildCase;
+  var id        = 'colorFontContrast';
+
+  /**
+   *
+   */
+  function colorFontContrast(test, Case, options, $this, element) {
+    // Check text and background color using DOM.
+    // Build a case.
+    if (!colors.testElmContrast(options.algorithm, $this)) {
+      buildCase(test, Case, element, 'failed', id, 'The font contrast of the text impairs readability');
     }
     else {
-      // Loop has to be separated. If we try to iterate and rund testCandidates
-      // the xpath thing will crash because document is being modified.
-      while (text) {
-        nodes.push(text);
-        text = textnodes.iterateNext();
-      }
-      nodes.forEach(function (textNode) {
-        quail.components.color.testCandidates('colorFontContrast', textNode, test, Case, options);
-      });
+      buildCase(test, Case, element, 'passed', id, 'The font contrast of the text is sufficient for readability');
     }
+  }
+
+
+  test.get('$scope').each(function () {
+    var textNodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+    var nodes = [];
+    var textNode = textNodes.iterateNext();
+
+    // Loop has to be separated. If we try to iterate and rund testCandidates
+    // the xpath thing will crash because document is being modified.
+    while (textNode) {
+      if (quail.components.color.textShouldBeTested(textNode)) {
+        nodes.push(textNode.parentNode);
+      }
+      textNode = textNodes.iterateNext();
+    }
+
+    if (nodes.length === 0) {
+      buildCase(test, Case, null, 'inapplicable', '', 'There is no text to evaluate');
+    }
+
+    nodes.forEach(function (element) {
+      colorFontContrast(test, Case, options, $(element), element);
+    });
   });
 };

--- a/src/js/lib/wcag2/testAggregator.js
+++ b/src/js/lib/wcag2/testAggregator.js
@@ -25,7 +25,7 @@ quail.lib.wcag2.TestAggregator = (function () {
 
   /**
    * Run the callback for each testcase within the array of tests
-   * @param  {array}   tests    
+   * @param  {array}   tests
    * @param  {Function} callback Given the parameters (test, testcase)
    */
   function eachTestCase(tests, callback) {
@@ -110,14 +110,17 @@ quail.lib.wcag2.TestAggregator = (function () {
    * Combine the test results of an Aggregator into asserts
    *
    * A combinbing aggregator is an aggregator which only fails if all it's tests fail
-   * 
+   *
    * @param  {Object} aggregator
    * @param  {Array[Object]} tests
    * @return {Array[Object]}         Array of Asserts
    */
   function getCombinedAssertions(aggregator, tests) {
-    var elms = getCommonElements(tests);
-    var assertions = createAssertionsForEachElement(elms, {
+    // element should already be unique, but some tests have bugs that cause them
+    // not to be. This prevents those problems from escalating
+    var elms = jQuery.unique(getCommonElements(tests));
+
+    var assertions = createAssertionsForEachElement(jQuery.unique(elms), {
       testCase: aggregator.id,
       outcome: {result: 'failed'}
     });
@@ -157,7 +160,7 @@ quail.lib.wcag2.TestAggregator = (function () {
    * Stack the test results of a aggregator into asserts
    *
    * A stacked aggregator is one that fails if any of the tests fail
-   * 
+   *
    * @param  {Object} aggregator
    * @param  {Array[Object]} tests
    * @return {Array[Object]}         Array of Asserts
@@ -208,7 +211,7 @@ quail.lib.wcag2.TestAggregator = (function () {
 
 
   /**
-   * Filter the data array so it only contains results 
+   * Filter the data array so it only contains results
    * from this aggregator
    * @param  {Array} data
    * @return {Array}


### PR DESCRIPTION
Build a catch for the color tests resolving on the same element multiple times. Also some major refactoring should hopefully make these tests easier to maintain and debug in the future. I'm still finding quite a lot of false positives in practice, but these changes should help find them.