### PR TITLE
aInPHasDistinctStyle new exceptions - correction

### DIFF
--- a/src/js/custom/aInPhasADistinctStyle.js
+++ b/src/js/custom/aInPhasADistinctStyle.js
@@ -72,6 +72,9 @@ quail.aInPHasADistinctStyle=function(quail, test, Case){
       if (aText === '' || pText.match(allowedPText)) {
         _case.set('status', 'inapplicable');
 
+      } else if ($this.css('color') === $p.css('color')) {
+        _case.set('status', 'passed');
+
       } else if (elmHasDistinctStyle($this, $p)) {
         _case.set('status', 'passed');
 

--- a/src/js/custom/aInPhasADistinctStyle.js
+++ b/src/js/custom/aInPhasADistinctStyle.js
@@ -12,7 +12,7 @@ quail.aInPHasADistinctStyle=function(quail, test, Case){
 
   /**
    * Test if two elements have a distinct style from it's ancestor
-   * @param  {jQuery node} $elm    
+   * @param  {jQuery node} $elm
    * @param  {jQuery node} $parent
    * @return {boolean}
    */
@@ -46,6 +46,8 @@ quail.aInPHasADistinctStyle=function(quail, test, Case){
     return isBlock || isPositioned;
   }
 
+  // Ignore links where the p only contains white space, <, >, |, \, / and - chars
+  var allowedPText = /^([\s|-]|>|<|\\|\/|&(gt|lt);)*$/i;
 
   test.get('$scope').each(function () {
     var $scope = $(this);
@@ -63,9 +65,11 @@ quail.aInPHasADistinctStyle=function(quail, test, Case){
       test.add(_case);
 
       var aText = $this.text().trim();
-      var pText = $p.text().trim();
 
-      if (aText === '' || aText === pText) {
+      // Get all text of the p element with all anchors removed
+      var pText = $p.clone().find('a[href]').remove().end().text();
+
+      if (aText === '' || pText.match(allowedPText)) {
         _case.set('status', 'inapplicable');
 
       } else if (elmHasDistinctStyle($this, $p)) {

--- a/test/accessibility-tests/aInPHasADistinctStyle.html
+++ b/test/accessibility-tests/aInPHasADistinctStyle.html
@@ -173,6 +173,16 @@
         inside it.</p>
 </div>
 
+<div class="quail-test" data-expected="pass"
+     data-accessibility-test="aInPHasADistinctStyle">
+    <p>Some text
+        <a href="/" style="color:black">
+            With a link
+        </a>
+        that is identical.
+        This sometimes happens in page footers with an e-mail address</p>
+</div>
+
 <div class="quail-test" data-expected="fail"
      data-accessibility-test="aInPHasADistinctStyle">
     <p style="text-decoration:underline">Some text

--- a/test/accessibility-tests/aInPHasADistinctStyle.html
+++ b/test/accessibility-tests/aInPHasADistinctStyle.html
@@ -109,6 +109,29 @@
         inside it.</p>
 </div>
 
+
+<div class="quail-test" data-expected="inapplicable"
+           data-accessibility-test="aInPHasADistinctStyle">
+    <!-- links with images are probably sufficiently distinguishable -->
+    <p>
+      <a href="/">Allow multiple links</a>
+      <a href="/">Inside a paragraph</a>
+    </p>
+</div>
+
+<div class="quail-test" data-expected="inapplicable"
+           data-accessibility-test="aInPHasADistinctStyle">
+    <!-- links with images are probably sufficiently distinguishable -->
+    <p>
+      <a href="/">Allow</a> |
+      <a href="/">For</a> -
+      <a href="/">Certain</a> >
+      <a href="/">Types</a> &gt;
+      <a href="/">Of</a> &lt;
+      <a href="/">Separators</a>
+    </p>
+</div>
+
 <div class="quail-test" data-expected="pass"
      data-accessibility-test="aInPHasADistinctStyle">
     <!-- If the link is the only content of an element
@@ -131,13 +154,13 @@
         </a> </strong>,
         <em><a href="/">
             With a link
-        </a></em> - 
+        </a></em> -
         <b><a href="/">
             With a link
         </a></b>  ====
         <u><a href="/">
             With a link
-        </a></u> / 
+        </a></u> /
         inside it.</p>
 </div>
 


### PR DESCRIPTION
Anchors in p are not always a problem. A few observed exceptions have been added, particularly for single line navigation components such as bread crumb trails.