### PR TITLE
Use async $.ajax call to load tests json

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -191,7 +191,6 @@ var quail = {
 
       $.ajax({
         url : url + '/tests.json',
-        async : false,
         dataType : 'json',
         success : function (data) {
           if (typeof data === 'object') {


### PR DESCRIPTION
## Problem Source

Synchronous version causes a nasty bug in FF (Windows client) resulting with some extra `keypress` events being fired, as explained in [bugzilla#489375](https://bugzilla.mozilla.org/show_bug.cgi?id=489375#c6). More information:

> This issue occurs only on FireFox. Use Enter key to trigger sync AJAX request. Note that selection must be in div#selectionContainer.
>
> You should have one new line inserted for press. This is because we don't cancel the event. But it turns that FF will insert 2 line breaks.
>
> What about canceled event? Well if you'll cancel the event it will still insert 1 line break, even though you explicitly denied it.

I've created [a demo](https://bug489375.bugzilla.mozilla.org/attachment.cgi?id=8599425) that showcases the problem.

### Affected Branch

This particular case applies to branch **2.2.x** as in **master** I see that it's solved differently.

### Other Synchronous AJAX requests

I do see a few other synchronous AJAX requests, but they're not that important as this one, as i assume most of other requestests are called from tests which would be ran inside some `setTimeout` call, that eliminates mentioned FF issue.

Related issue: cksource/quail#8.