### PR TITLE
Typo in documentVisualListsAreMarkedUp

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -1339,8 +1339,8 @@ documentVisualListsAreMarkedUp:
     en: "Visual lists of items are marked using ordered or unordered lists"
     nl: "Lijsten moeten gemarkeerd worden als ordered of unordered lists"
   description:
-    en: "Use the ordered (<code>ol</code>.  or unordered (<code>ul</code>.  elements for lists of items, instead of just using new lines which start with numbers or characters to create a visual list."
-    nl: "Gebruik ordered (<code>ol</code>. of unordered (<code>ul</code>. elementen voor lijsten, in plaats van een nieuwe regel per item aan te maken die je laat beginnen met een nummer of teken om een visuele lijst te maken."
+    en: "Use the ordered (<code>ol</code>) or unordered (<code>ul</code>) elements for lists of items, instead of just using new lines which start with numbers or characters to create a visual list."
+    nl: "Gebruik ordered (<code>ol</code>) of unordered (<code>ul</code>) elementen voor lijsten, in plaats van een nieuwe regel per item aan te maken die je laat beginnen met een nummer of teken om een visuele lijst te maken."
   guidelines:
     wcag:
       1.3.1:


### PR DESCRIPTION
Looks like desc for this assessment contains an typo. They say:

> A picture is worth a thousand words.

So here it is:

![pasted_image_at_2015_05_11_03_41_pm](https://cloud.githubusercontent.com/assets/5353898/7566421/fadf6dec-f7f6-11e4-83af-539ae39c127d.png)

(it's all about dot instead of parenthesis)

Source issue: cksource/quail#9