### PR TITLE
Typo in pNotUsedAsHeader

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -3760,8 +3760,8 @@ pNotUsedAsHeader:
     en: "Paragraphs must not be used for headers"
     nl: "Alinea's worden niet gebruikt als header"
   description:
-    en: "Headers like <code>h1</code>. h6 are extremely useful for non-sighted users to navigate the structure of the page, and formatting a paragraph to just be big or bold, while it might visually look like a header, does not make it one."
-    nl: "Headers van <code>h1</code>. h6 zijn handig voor blinde en slechtziende gebruikers om door een pagina te navigeren. Maak alinea's daarom niet op zodat deze lijkt op een header. Dit werkt verwarrend."
+    en: "Headers like <code>h1</code> - <code>h6</code> are extremely useful for non-sighted users to navigate the structure of the page, and formatting a paragraph to just be big or bold, while it might visually look like a header, does not make it one."
+    nl: "Headers van <code>h1</code> - <code>h6</code> zijn handig voor blinde en slechtziende gebruikers om door een pagina te navigeren. Maak alinea's daarom niet op zodat deze lijkt op een header. Dit werkt verwarrend."
   guidelines:
     wcag:
       1.3.1:


### PR DESCRIPTION
Is:
```
description:
    en: "Headers like <code>h1</code>. h6 are extremely useful for non-sighted users to navigate the structure of the page, and formatting a paragraph to just be big or bold, while it might visually look like a header, does not make it one."
```

Should be:
```
description:
    en: "Headers like <code>h1</code> - <code>h6</code> are extremely useful for non-sighted users to navigate the structure of the page, and formatting a paragraph to just be big or bold, while it might visually look like a header, does not make it one."
```

Originated from: cksource/quail#10