### PR TITLE
Typo in aAdjacentWithSameResourceShouldBeCombined

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -5,7 +5,7 @@ aAdjacentWithSameResourceShouldBeCombined:
     en: "Adjacent links that point to the same location should be merged"
     nl: "Voeg naast elkaar gelegen links die naar dezelfde locatie verwijzen samen"
   description:
-    en: "Because many users of screen-readers use links to navigate the page, providing two links right next to eachother that point to the same location can be confusing. Try combining the links."
+    en: "Because many users of screen-readers use links to navigate the page, providing two links right next to each other that point to the same location can be confusing. Try combining the links."
     nl: "Veel gebruikers van schermlezers gebruiken links om op de pagina te navigeren. Voor hen zijn naast elkaar gelegen links die naar dezelfde locatie verwijzen verwarrend. Probeer de links samen te voegen."
   guidelines:
     wcag:


### PR DESCRIPTION
Is:
```
  description:
    en: "Because many users of screen-readers use links to navigate the page, providing two links right next to eachother that point to the same location can be confusing. Try combining the links."
```


Should be:
```
  description:
    en: "Because many users of screen-readers use links to navigate the page, providing two links right next to each other that point to the same location can be confusing. Try combining the links."

```

Originated from: cksource/quail#12