### PR TITLE
Fix color gradient test failures

### DIFF
--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -266,7 +266,7 @@ quail.components.color = (function () {
           colors.cache[cacheKey] = false;
           return false;
         }
-        var bimage = $(element).css('backgroundImage');
+        var bimage = $(element).css('background-image');
         if (bimage && bimage !== 'none' && bimage.search(/^(.*?)gradient(.*?)$/i) !== -1) {
           var gradient = bimage.match(/gradient(\(.*\))/g);
           if (gradient.length > 0) {

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -403,7 +403,7 @@ quail.components.color = (function () {
           if (bimage && bimage !== 'none' && bimage.search(/^(.*?)gradient(.*?)$/i) !== -1) {
             var gradient = bimage.match(/gradient(\(.*\))/g);
             if (gradient.length > 0) {
-              gradient = gradient[0].replace(/(linear|radial|from|\bto\b|gradient|top|left|bottom|right|\d*%)/g, '');
+              gradient = gradient[0].replace(/(linear|radial|from|\bto\b|gradient|top|left|bottom|right|color-stop|center|\d*%)/g, '');
               foundIt = $.grep(gradient.match(/(rgb\([^\)]+\)|#[a-z\d]*|[a-z]*)/g), notempty);
             }
           }

--- a/src/js/components/color.js
+++ b/src/js/components/color.js
@@ -270,7 +270,7 @@ quail.components.color = (function () {
         if (bimage && bimage !== 'none' && bimage.search(/^(.*?)gradient(.*?)$/i) !== -1) {
           var gradient = bimage.match(/gradient(\(.*\))/g);
           if (gradient.length > 0) {
-            gradient = gradient[0].replace(/(linear|radial|from|\bto\b|gradient|top|left|bottom|right|\d*%)/g, '');
+            gradient = gradient[0].replace(/(linear|radial|from|\bto\b|gradient|top|left|bottom|right|color-stop|center|\d*%)/g, '');
             colors.cache[cacheKey] = $.grep(gradient.match(/(rgb\([^\)]+\)|#[a-z\d]*|[a-z]*)/g), notEmpty);
             return colors.cache[cacheKey];
           }

--- a/src/js/custom/colorBackgroundGradientContrast.js
+++ b/src/js/custom/colorBackgroundGradientContrast.js
@@ -1,7 +1,7 @@
 quail.colorBackgroundGradientContrast = function (quail, test, Case, options) {
 
   var colors    = quail.components.color.colors;
-  var buildCase =  quail.components.color.buildCase;
+  var buildCase = quail.components.color.buildCase;
   var id        = 'colorBackgroundGradientContrast';
 
   /**
@@ -50,11 +50,12 @@ quail.colorBackgroundGradientContrast = function (quail, test, Case, options) {
 
 
   test.get('$scope').each(function () {
+
     var textNodes = document.evaluate('descendant::text()[normalize-space()]', this, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
     var nodes     = [];
     var textNode  = textNodes.iterateNext();
 
-    // Loop has to be separated. If we try to iterate and rund testCandidates
+    // Loop has to be separated. If we try to iterate and run testCandidates
     // the xpath thing will crash because document is being modified.
     while (textNode) {
       if (quail.components.color.textShouldBeTested(textNode)) {

--- a/test/accessibility-tests/colorBackgroundGradientContrast.html
+++ b/test/accessibility-tests/colorBackgroundGradientContrast.html
@@ -6,42 +6,62 @@
     #test-1 p {
       color: #fff;
       padding: 10px;
-      background-image: linear-gradient(to bottom, #de88de, #98afd6);
+      background-image: -webkit-linear-gradient(0deg, #de88de, #98afd6);
+      background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#de88de), color-stop(100%,#98afd6));
+      background-image: -moz-linear-gradient(0deg, #de88de, #98afd6);
+      background-image: -o-linear-gradient(0deg, #de88de, #98afd6);
+      background-image: -ms-linear-gradient(0deg, #de88de, #98afd6);
+      background-image: linear-gradient(0deg, #de88de, #98afd6);
     }
     #test-2 p {
       color: #fff;
       padding: 10px;
-      background-image: linear-gradient(to bottom, #610061, #032966);
+      background-image: -webkit-linear-gradient(0deg, #610061, #032966);
+      background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#610061), color-stop(100%,#032966));
+      background-image: -moz-linear-gradient(0deg, #610061, #032966);
+      background-image: -o-linear-gradient(0deg, #610061, #032966);
+      background-image: -ms-linear-gradient(0deg, #610061, #032966);
+      background-image: linear-gradient(0deg, #610061, #032966);
     }
 
     #test-3 p {
       color: #fff;
       padding: 10px;
-      background-image: linear-gradient(to right, red, #f06d06, rgb(255, 255, 0), green);
+      background-image: -webkit-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background: -webkit-gradient(linear, left top, right top, color-stop(0%,#ff0000), color-stop(25%,#f06d06), color-stop(25%,#f06d06), color-stop(50%,#ffff00), color-stop(75%,#008000), color-stop(100%,#008000));
+      background-image: -moz-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background-image: -o-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background-image: -ms-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background-image: linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
     }
 
     #test-4 {
       color: #fff;
       padding: 10px;
-      background-image: radial-gradient(red, #f06d06, rgb(255, 255, 0), green);
+      background-image: -webkit-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%,#ff0000), color-stop(25%,#f06d06), color-stop(50%,#ffff00), color-stop(75%,#008000), color-stop(100%,#008000));
+      background-image: -moz-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -o-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -ms-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
       text-align: center;
     }
   </style>
 </head>
 <body>
-  <div class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast" id="test-1">
+  <div id="test-1" class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast">
     <p>This test is not readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorBackgroundGradientContrast:pass" data-accessibility-test="colorBackgroundGradientContrast" id="test-2">
+  <div id="test-2" class="quail-test" data-expected="colorBackgroundGradientContrast:pass" data-accessibility-test="colorBackgroundGradientContrast">
     <p>This test is readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast" id="test-3">
+  <div id="test-3" class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast">
     <p>This test is not readable</p>
   </div>
 
-  <div class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast" id="test-4">
+  <div id="test-4" class="quail-test" data-expected="colorBackgroundGradientContrast:fail" data-accessibility-test="colorBackgroundGradientContrast">
     <p>This test is not readable, but on screen it is</p>
   </div>
 

--- a/test/accessibility-tests/colorBackgroundGradientContrast.html
+++ b/test/accessibility-tests/colorBackgroundGradientContrast.html
@@ -28,7 +28,7 @@
       color: #fff;
       padding: 10px;
       background-image: -webkit-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
-      background: -webkit-gradient(linear, left top, right top, color-stop(0%,#ff0000), color-stop(25%,#f06d06), color-stop(25%,#f06d06), color-stop(50%,#ffff00), color-stop(75%,#008000), color-stop(100%,#008000));
+      background-image: -webkit-gradient(linear, left top, right top, color-stop(0%,#ff0000), color-stop(25%,#f06d06), color-stop(25%,#f06d06), color-stop(50%,#ffff00), color-stop(75%,#008000), color-stop(100%,#008000));
       background-image: -moz-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
       background-image: -o-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
       background-image: -ms-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);

--- a/test/accessibility-tests/colorElementBehindBackgroundGradientContrast.html
+++ b/test/accessibility-tests/colorElementBehindBackgroundGradientContrast.html
@@ -6,13 +6,23 @@
     #test-1 {
       color: #fff;
       padding: 10px;
-      background-image: radial-gradient(red, #f06d06, rgb(255, 255, 0), green);
+      background-image: -webkit-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%,#ff0000), color-stop(25%,#f06d06), color-stop(50%,#ffff00), color-stop(75%,#008000), color-stop(100%,#008000));
+      background-image: -moz-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -o-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -ms-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
       text-align: center;
     }
     #test-2 {
       color: #000;
       padding: 10px;
-      background-image: radial-gradient(red, #f06d06, rgb(255, 255, 0), green);
+      background-image: -webkit-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%,#ff0000), color-stop(25%,#f06d06), color-stop(50%,#ffff00), color-stop(75%,#008000), color-stop(100%,#008000));
+      background-image: -moz-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -o-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: -ms-radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
+      background-image: radial-gradient(#ff0000, #f06d06, #ffff00, #008000);
       text-align: center;
     }
     #test-2 p {
@@ -23,7 +33,12 @@
       padding: 0;
     }
     #test-3 .bck {
-      background-image: linear-gradient(to right, red, #f06d06, rgb(255, 255, 0), green);
+      background-image: -webkit-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background-image: -webkit-gradient(linear, left top, right top, color-stop(0%,#ff0000), color-stop(25%,#f06d06), color-stop(25%,#f06d06), color-stop(50%,#ffff00), color-stop(75%,#008000), color-stop(100%,#008000));
+      background-image: -moz-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background-image: -o-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background-image: -ms-linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
+      background-image: linear-gradient(to right, #ff0000, #f06d06, #ffff00, #008000);
       height: 50px;
       width: 100%;
       position: absolute;


### PR DESCRIPTION
We have two failures keeping us from a green board on master-2.2.x. The behavior was that no assertions got made for either assessment. These assessments deal with validating color contrast against gradients.

Turns out that PhantomJS, depending on the version of Webkit its running, only supports older style ```-webkit-gradient()``` CSS gradient declarations. Our test HTML files didn't include this type of vendor prefixing. 

By adding the prefixing, it revealed a bug in our regex parsing of CSS gradient background declaration for older Webkits. lolz. 

Should be fixed now. Waiting on Travis.